### PR TITLE
exporting Validator & Filter references

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -80,3 +80,5 @@ var expressValidator = function(req, res, next) {
   return next();
 };
 module.exports = expressValidator;
+module.exports.Validator = Validator;
+module.exports.Filter = Filter;


### PR DESCRIPTION
I wanted to add a sanitize method for "toLowerCase" (so that I could string it together with the rest of the included sanitizers), but it looks like there is no easy way of doing so when using express-validator because the Filter object isn't exposed. This patch exports both the Filter and Validator so folks like me can easily do this:

``` javascript
var expressValidator = require('express-validator');

expressValidator.Filter.prototype.toLowerCase = function(){
  this.modify(this.str.toLowerCase());
  return this.str;
};
```

... unless there is an easy way to do this already?
