### PR TITLE
get complete error objects

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -46,10 +46,29 @@ var expressValidator = function(req, res, next) {
   };
 
   req.check = function(param, fail_msg) {
+
+    var value;
+    // get value and param name for nested inputs like foo[bar][baz]
+
+    if(Array.isArray(param)) {
+      param.map(function(item) {
+        if(value === undefined) {
+          value = req.param(item);
+        } else {
+          value = value[item];
+        }
+      });
+      param = param.join('_');
+
+    } else {
+      value = this.param(param);
+    }
+
     validator.error = function(msg) {
       var error = {
         param: param,
-        msg: msg
+        msg: msg,
+        value: value
       }
       if (req._validationErrors === undefined) {
         req._validationErrors = [];
@@ -60,7 +79,7 @@ var expressValidator = function(req, res, next) {
         req.onErrorCallback(msg);
       }
     }
-    return validator.check(this.param(param), fail_msg);
+    return validator.check(value, fail_msg);
   };
 
   req.checkHeader = function(param, fail_msg) {
@@ -84,7 +103,7 @@ var expressValidator = function(req, res, next) {
     if (mapped) {
       var errors = {};
       req._validationErrors.map(function(err) {
-        errors[err.param] = err.msg;
+        errors[err.param] = err;
       });
       return errors;
     } else {


### PR DESCRIPTION
I managed to fix my previous pull request :)
usage example:

<pre>
req.assert('email', 'required').notEmpty();
req.assert('email', 'valid email required').isEmail();
req.assert('password', '6 to 20 characters required').len(6, 20);

var errors = req.validationErrors();
var mappedErrors = req.validationErrors(true);
</pre>

errors:

<pre>
[
  {param: "email", msg: "required", value: "&lt;received input&gt;"},
  {param: "email", msg: "valid email required", value: "&lt;received input&gt;"},
  {param: "password", msg: "6 to 20 characters required", value: "&lt;received input&gt;"}
]
</pre>

mappedErrors:

<pre>
{
  email: {
    param: "email",
    msg: "valid email required",
    value: "&lt;received input&gt;"
  },
  password: {
    param: "password",
    msg: "6 to 20 characters required",
    value: "&lt;received input&gt;"
  }
}
</pre>
