### PR TITLE
Fix chaining validators

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -77,6 +77,7 @@ var expressValidator = function(req, res, next) {
       if (req.onErrorCallback) {
         req.onErrorCallback(msg);
       }
+      return this;
     }
     return validator.check(value, fail_msg);
   };


### PR DESCRIPTION
https://github.com/chriso/node-validator/commit/3bca87306e43572ba3643e56
6c662f474747466c
Above commit from node-validator@0.4.6-2 rendered express-validator
buggy when chaining validators got error. Required to return the validator itself instead of undefined.

Example: 
// Error if isInt() assertion failed, returning undefined
req.assert('zipcode', 'not zipcode').isInt().len(7); 
