### PR TITLE
Support for interruting validation executing when error happened

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -39,7 +39,7 @@ var expressValidator = function(options) {
   };
 
   function checkParam(req, getter) {
-    return function(param, fail_msg) {
+    return function(param, fail_msg, validationFunc) {
 
       var value;
 
@@ -67,7 +67,7 @@ var expressValidator = function(options) {
       });
       param = param.join('.');
 
-      validator.error = function(msg) {
+      var error = function(msg) {
         var error = _options.errorFormatter(param, msg, value);
 
         if (req._validationErrors === undefined) {
@@ -79,8 +79,20 @@ var expressValidator = function(options) {
           req.onErrorCallback(msg);
         }
         return this;
+      };
+      validator.error = function(msg) {
+        error(msg);
+        throw new Error('Validation Error');
+      };
+      var context = validator.check(value, fail_msg);
+      try {
+        validationFunc.call(context);
+      } catch(e) {
+        // do nothing
       }
-      return validator.check(value, fail_msg);
+
+      validator.error = error;
+      return context;
     }
   }
   return function(req, res, next) {


### PR DESCRIPTION
hi, I developed a new feature. Here it is.

The Problem
===========

When we do this:

    req.checkBody('postparam', {notEmpty: 'Must not be empty', isInt: 'Must be Int'}).notEmpty().isInt();

and the `postparam` value is an empty string, 

    var errors = req.validationErrors();
    console.log(errors);

what we get is:

    [
      {param: "postparam", msg: "Must not be empty", value: ""},
      {param: "postparam", msg: "Must be Int", value: ""},
    ]

The problem is that the execution of `isInt` is completely unnecessary and even further in some validation function we will have to write some protection code in case of some unexpected value appear as parameter. We only want the value getting passed in when it fullfills the previous validation so that we can avoid the protection codes.

And when we do this:

    var errors = req.validationErrors(true);
    console.log(errors);

we get

    {
      postparam: {
        param: "postparam",
        msg: "Must be Int",
        value: ""
      }
    }

You see that? In most cases, we want the msg 'Must not be empty' instead of 'Must be int'.

The Solution
===========

So I developed this feature: 

     Validation executing will be stopped immediately when any error happened.

Here is the example: 

    req.checkBody('postparam', {notEmpty: 'Must not be empty', isInt: 'Must be Int'}, function() {
      this.notEmpty().isInt()
    });

when the `postparam` value is an empty string,

    var errors = req.validationErrors();
    console.log(errors);

what we get is:

    [
      {param: "postparam", msg: "Must not be empty", value: ""}
    ]

See? Only one message.

when we do this:

    var errors = req.validationErrors(true);
    console.log(errors);

we get

    {
      postparam: {
        param: "postparam",
        msg: "Must not be empty",
        value: ""
      }
    }

Yes, the expected msg is returned.

## The original way remains supported as expected. ##

What do you think?