### PR TITLE
errorFormatter called with the request as this / bracket notation/ array index

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -45,7 +45,7 @@ var expressValidator = function(options) {
     return function(param, fail_msg) {
 
       var value;
-
+      var paramPath = param;
       // If param is not an array, then split by dot notation
       // returning an array. It will return an array even if
       // param doesn't have the dot notation.
@@ -68,9 +68,12 @@ var expressValidator = function(options) {
               if (typeof param[i] === 'string') {
                   tmp = param[i].split(/\]\[|\]|\[/g).filter(function(e){
                       return e !== '';
-                  });;
+                  });
+                  tmpArr.push.apply(tmpArr, tmp);
+              } else {
+                  tmpArr.push(tmp);
               }
-              tmpArr.push.apply(tmpArr, tmp);
+
 
         }
         param = tmpArr;
@@ -93,7 +96,10 @@ var expressValidator = function(options) {
             }
           }
       });
-      param = param.join('.');
+
+      if (Array.isArray(paramPath)) {
+          param = param.join('.');
+      }
 
       validator.error = function(msg) {
         var error = _options.errorFormatter.call(req, param, msg, value);

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -98,11 +98,11 @@ var expressValidator = function(options) {
       });
 
       if (Array.isArray(paramPath)) {
-          param = param.join('.');
+          paramPath = paramPath.join('.');
       }
 
       validator.error = function(msg) {
-        var error = _options.errorFormatter.call(req, param, msg, value);
+        var error = _options.errorFormatter.call(req, paramPath, msg, value);
 
         if (req._validationErrors === undefined) {
           req._validationErrors = [];

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -26,7 +26,9 @@ var Validator = require('validator').Validator,
 var validator = new Validator();
 
 var expressValidator = function(options) {
+
   options = options || {};
+  validator = options.validator || validator;
 
   var _options = {};
 

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -68,7 +68,7 @@ var expressValidator = function(options) {
       param = param.join('.');
 
       validator.error = function(msg) {
-        var error = _options.errorFormatter(param, msg, value);
+        var error = _options.errorFormatter.call(req, param, msg, value);
 
         if (req._validationErrors === undefined) {
           req._validationErrors = [];
@@ -83,6 +83,7 @@ var expressValidator = function(options) {
       return validator.check(value, fail_msg);
     }
   }
+
   return function(req, res, next) {
 
     req.updateParam = function(name, value) {

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -21,7 +21,8 @@
  */
 
 var Validator = require('validator').Validator,
-    Filter = require('validator').Filter;
+    Filter = require('validator').Filter,
+    _ = require('underscore');
 
 var validator = new Validator();
 
@@ -57,6 +58,23 @@ var expressValidator = function(options) {
                 param.split('.').filter(function(e){
                   return e !== '';
                 });
+
+
+        // flatten bracket notation for each param path item
+        //      users[0][name] -> ['users', '0', 'name']
+        var tmpArr = [];
+        for (var i= 0; i < param.length; i++) {
+              var tmp = param[i];
+              if (typeof param[i] === 'string') {
+                  tmp = param[i].split(/\]\[|\]|\[/g).filter(function(e){
+                      return e !== '';
+                  });;
+              }
+              tmpArr.push.apply(tmpArr, tmp);
+
+        }
+        param = tmpArr;
+
       }
 
       // Extract value from params
@@ -65,6 +83,14 @@ var expressValidator = function(options) {
             value = getter(item)
           } else {
             value = value[item];
+
+            // if no value is found for this item, see if item is an array index
+            if (value === undefined) {
+                item = parseInt(item);
+                if (!_.isNaN(item)) {
+                    value = value[item];
+                }
+            }
           }
       });
       param = param.join('.');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "node": "*"
   },
   "dependencies": {
-    "validator": "1.5.0"
+    "validator": "1.5.0",
+    "underscore": "~1.5.1"
   },
   "devDependencies": {
     "async": "~0.1.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": "*"
   },
   "dependencies": {
-    "validator": "1.2.1"
+    "validator": "1.5.0"
   },
   "devDependencies": {
     "async": "~0.1.22",

--- a/test/errorFormatter.js
+++ b/test/errorFormatter.js
@@ -1,0 +1,61 @@
+var assert = require('assert');
+var async = require('async');
+var http = require('http');
+
+var App = require('./helpers/app');
+var req = require('./helpers/req');
+
+var port = process.env.NODE_HTTP_PORT || 8888;
+var url = 'http://localhost:' + port;
+
+// There are three ways to pass parameters to express:
+// - as part of the URL
+// - as GET parameter in the querystring
+// - as POST parameter in the body
+// URL params take precedence over GET params which take precedence over
+// POST params.
+
+var errorMessage = 'Parameter is not an integer';
+var validation = function(req, res) {
+    req.assert('testparam', errorMessage).notEmpty().isInt();
+
+    var errors = req.validationErrors();
+    if (errors) {
+        res.json(errors);
+        return;
+    }
+    res.json({testparam: req.param('testparam')});
+};
+var app = new App(port, validation, {
+    errorFormatter: function(param, msg, value) {
+        assert.ok(this instanceof http.IncomingMessage);
+        return {
+            param: param,
+            msg: msg,
+            value: value
+        }
+    }
+});
+app.start();
+
+function fail(body) {
+    assert.equal(body.length, 1);
+    assert.deepEqual(body[0].msg, errorMessage);
+}
+function pass(body) {
+    assert.deepEqual(body, {testparam: 123});
+}
+
+var tests = [
+    // Test URL param
+    async.apply(req, 'get', url + '/test', fail),
+    async.apply(req, 'get', url + '/123', pass),
+    async.apply(req, 'post', url + '/test', fail),
+    async.apply(req, 'post', url + '/123', pass)
+];
+
+async.parallel(tests, function(err) {
+    assert.ifError(err);
+    app.stop();
+    console.log('All %d tests passed.', tests.length);
+});

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -2,10 +2,11 @@
 var express = require('express');
 var expressValidator = require('../../index');
 
-function App(port, validation) {
+function App(port, validation, validatorOptions) {
   this.app = null;
   this.port = port;
   this.validation = validation;
+  this.options = validatorOptions;
 }
 module.exports = App;
 
@@ -14,7 +15,7 @@ App.prototype.start = function() {
   self.app = express.createServer();
 
   self.app.use(express.bodyParser());
-  self.app.use(expressValidator());
+  self.app.use(expressValidator(this.options));
 
   self.app.get(/\/test(\d+)/, self.validation);
   self.app.get('/:testparam?', self.validation);

--- a/test/nested.js
+++ b/test/nested.js
@@ -39,6 +39,7 @@ function pass(body) {
   });
 }
 
+
 var tests = [
   async.apply(req, 'post', url + '/', {
     json: {

--- a/test/nestedArray.js
+++ b/test/nestedArray.js
@@ -1,0 +1,78 @@
+var assert = require('assert');
+var async = require('async');
+
+var App = require('./helpers/app');
+var req = require('./helpers/req');
+
+var port = process.env.NODE_HTTP_PORT || 8888;
+var url = 'http://localhost:' + port;
+
+// Nested parameters are also supported
+
+var validation = function(req, res) {
+    req.assert(['users', '0', 'fields', 'email'], 'not empty').notEmpty();
+    //req.assert('user.fields.email', 'not empty').notEmpty();
+    req.assert(['users', 0, 'fields', 'email'], 'valid email required').isEmail();
+    req.assert('users[0].fields.email', 'not empty').notEmpty();
+    req.assert('users[0].fields.email', 'valid email required').isEmail();
+    req.assert('users[0][fields][email]', 'not empty').notEmpty();
+    req.assert('users[0][fields][email]', 'valid email required').isEmail();
+
+    var errors = req.validationErrors();
+    if (errors) {
+        res.json(errors);
+        return;
+    }
+    res.json(req.body);
+};
+var app = new App(port, validation);
+app.start();
+
+function fail(body) {
+    assert.deepEqual(body[0].msg, 'not empty');
+    assert.deepEqual(body[1].msg, 'not empty');
+    assert.deepEqual(body[2].msg, 'valid email required');
+}
+
+function pass(body) {
+    assert.deepEqual(body, {
+        users: [
+            {
+                fields: {
+                    email: 'test@example.com'
+                }
+            },
+            {
+                fields: {
+                    email: 'test2@example.com'
+                }
+            }
+        ]
+    });
+}
+
+var tests = [
+
+    async.apply(req, 'post', url + '/', {
+        json: {
+            users: [
+                {
+                    fields: {
+                        email: 'test@example.com'
+                    }
+                },
+                {
+                    fields: {
+                        email: 'test2@example.com'
+                    }
+                }
+            ]
+        }
+    }, pass)
+];
+
+async.parallel(tests, function(err) {
+    assert.ifError(err);
+    app.stop();
+    console.log('All %d tests passed.', tests.length);
+});

--- a/test/substituteValidator.js
+++ b/test/substituteValidator.js
@@ -1,0 +1,67 @@
+var assert = require('assert');
+var async = require('async');
+var http = require('http');
+var Validator = require('validator').Validator;
+
+var App = require('./helpers/app');
+var req = require('./helpers/req');
+
+var port = process.env.NODE_HTTP_PORT || 8888;
+var url = 'http://localhost:' + port;
+
+// There are three ways to pass parameters to express:
+// - as part of the URL
+// - as GET parameter in the querystring
+// - as POST parameter in the body
+// URL params take precedence over GET params which take precedence over
+// POST params.
+
+var errorMessage = 'Parameter is not an integer';
+var validation = function(req, res) {
+    req.assert('testparam', errorMessage).notEmpty().isInt();
+
+    var errors = req.validationErrors();
+    if (errors) {
+        res.json(errors);
+        return;
+    }
+    res.json({testparam: req.param('testparam')});
+};
+
+var callCount = 0;
+
+var app = new App(port, validation, {
+    validator: new Validator({
+        messageBuilder: function(msg, args) {
+            callCount++;
+            if (typeof msg === 'string') {
+                args.forEach(function(arg, i) { msg = msg.replace('%'+i, arg); });
+            }
+            return msg;
+        }
+    })
+});
+app.start();
+
+function fail(body) {
+    assert.equal(body.length, 1);
+    assert.deepEqual(body[0].msg, errorMessage);
+}
+function pass(body) {
+    assert.deepEqual(body, {testparam: 123});
+}
+
+var tests = [
+    // Test URL param
+    async.apply(req, 'get', url + '/test', fail),
+    async.apply(req, 'get', url + '/123', pass),
+    async.apply(req, 'post', url + '/test', fail),
+    async.apply(req, 'post', url + '/123', pass)
+];
+
+async.parallel(tests, function(err) {
+    assert.ifError(err);
+    assert.equal(callCount, 2);
+    app.stop();
+    console.log('All %d tests passed.', tests.length);
+});


### PR DESCRIPTION
The idea is to call errorFormatter() with the request as this to allow an errorFormatter custom implementation to make use of other information/functions stored on the request for the formatting of the error.

My practical case is to internationalize the message thanks to the user's locale stored along each request.

I also added:
* support for array index when defining the param path like 
    req.checkBody(['users', 0, 'name'], 'error message').notEmpty()
* support for bracket notation when defining the param path like
    req.checkBody('users[0][name]', 'error message').notEmpty()

Let me know what you think of this.