### PR TITLE
Ensure req.body is defined

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -107,7 +107,7 @@ var expressValidator = function(options) {
     });
 
     req.checkBody = checkParam(req, function(item) {
-      return req.body[item];
+      return req.body && req.body[item];
     });
 
     req.checkHeader = function(header, fail_msg) {


### PR DESCRIPTION
If for whatever reason the user hasn't included `bodyParser()`, trying to access `req.body` will cause a crash.  This guards against this scenario.
