### PR TITLE
Keep the Middleware Up-to-Date

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": "*"
   },
   "dependencies": {
-    "validator": "1.5.0"
+    "validator": "1.5.*"
   },
   "devDependencies": {
     "async": "~0.1.22",


### PR DESCRIPTION
Just changed the dependency to stay up to date with patches/security fixes in the main node-validator package. No API changes should occur in the 1.5.\* versions.
