### PR TITLE
As .xss() is removed from node-validator 2.0.0, changed example in comments.

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -13,7 +13,7 @@
  *    where errback receives a parameter containing the error message
  *
  * 2. To sanitize parameters, use `req.sanitize(param_name)`
- *        e.g. req.sanitize('large_text').xss();
+ *        e.g. req.sanitize('param1').toBoolean();
  *        e.g. req.sanitize('param2').toInt();
  *
  * 3. Done! Access your validated and sanitized paramaters through the


### PR DESCRIPTION
As .xss() is removed from node-validator 2.0.0, changed example in comments in lib/express-validator.js
