### PR TITLE
Added the option to clear errors after retrieving them

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -196,7 +196,7 @@ var expressValidator = function(options) {
       }
       if(clear) {
       // Clear errors after retrieving them
-        req._validationErrors = [];
+        req._validationErrors = undefined;
       }
       return errors;
     }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -179,18 +179,26 @@ var expressValidator = function(options) {
       req.onErrorCallback = errback;
     };
 
-    req.validationErrors = function(mapped) {
-      if (req._validationErrors === undefined) {
-        return null;
+    req.validationErrors = function(mapped, clear) {
+      var errors;
+      if (!req._validationErrors) {
+        errors = null;
       }
-      if (mapped) {
-        var errors = {};
+      else if (mapped) {
+        errors = {};
         req._validationErrors.forEach(function(err) {
           errors[err.param] = err;
         });
-        return errors;
+
       }
-      return req._validationErrors;
+      else {
+        errors = req._validationErrors;
+      }
+      if(clear) {
+      // Clear errors after retrieving them
+        req._validationErrors = [];
+      }
+      return errors;
     }
 
     req.filter = function(param) {


### PR DESCRIPTION
When using express-validator in multiple chained middlewares, it is useful to optionally clear the validation errors after retrieving them, so that errors from the last middleware don't interfere with the current middleware.

I have added an optional second parameter to the expressValidator.validationErrors method, that specifies whether the current errors should be cleared after retrieving them.

Example usage:
```js
var firstMiddleware = function(req, res, next) {
    req.checkParams("something", "No valid something specified").isInt();
    var errros = req.validationErrors(false, true); // this clears the errors
    if(errors) {
        // do stuff to handle validation error
        return next();
    }
    next();
};

var secondMiddleware = function(req, res, next) {
    req.checkQuery("p", "No valid p specified").notEmpty().isInt();
    var errors = req.validationErrors();
    // without this, errors would contain all the errors that have occurred in earlier middleware,
    // even though they have been handled
    if(errors) {
        // return some kind of error to the user
    }
    // do useful stuff
};

app.get("/:something", firstMiddleware, secondMiddleware);
```