### PR TITLE
Return sanitized value from req.sanitize()

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -49,6 +49,7 @@ var expressValidator = function(options) {
           var args = [value].concat(arguments);
           var result = validator[methodName].apply(validator, args);
           request.updateParam(param, result);
+          return result;
         }
       }
     });


### PR DESCRIPTION
In older versions of express-validator, the sanitized value was returned
from req.sanitize. With the shift to validator.js v3, that behavior was
lost.

For consistency, req.sanitize() should return the sanitized value, just
like validator.js.

Fixes #83
