### PR TITLE
Fix for checkHeader crash

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -168,9 +168,9 @@ var expressValidator = function(options) {
         var toCheck;
 
         if (header === 'referrer' || header === 'referer') {
-          toCheck = this.headers.referer;
+          toCheck = req.headers.referer;
         } else {
-          toCheck = this.headers[header];
+          toCheck = req.headers[header];
         }
         return toCheck || '';
     });


### PR DESCRIPTION
Updated the `checkHeader` property to not fail. See [Issue 85](https://github.com/ctavan/express-validator/issues/85) (shouldn't have closed it though!)
