### PR TITLE
Fixed arguments usage for strict compliance

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -44,7 +44,7 @@ var expressValidator = function(options) {
     Object.keys(validator).forEach(function(methodName) {
       if (methodName.match(/^to/) || sanitizers.indexOf(methodName) !== -1) {
         methods[methodName] = function() {
-          var args = Array.prototype.slice.call([value].concat(arguments));
+          var args = [value].concat(Array.prototype.slice.call(arguments));
           var result = validator[methodName].apply(validator, args);
           request.updateParam(param, result);
         }


### PR DESCRIPTION
Removed usage of:

```
var arguments = ...
```
