### PR TITLE
Reverse order when mapping errors

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -213,7 +213,7 @@ var expressValidator = function(options) {
       }
       if (mapped) {
         var errors = {};
-        req._validationErrors.forEach(function(err) {
+        req._validationErrors.reverse().forEach(function(err) {
           errors[err.param] = err;
         });
         return errors;


### PR DESCRIPTION
When I use express-validator, I like to map errors to handle these like that in my views : 

    <% if(errors && errors.email) { %>
    <div class="error"><%= errors.email.msg %></div>
    <% } %>

The problem is that when there's multiples errors on a field : 

    req.assert('email', 'Email required).notEmpty();    
    req.assert('email', 'Invalid email').isEmail();    	

mapping process only keeping the last error, in my example "Invalid email" while email field is empty.

To avoid this, I simply reversed the array before map.