### PR TITLE
replaced request.param(item) with request.body[item]

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -173,7 +173,7 @@ var expressValidator = function(options) {
     };
 
     req.check = checkParam(req, function(item) {
-      return req.param(item);
+      return req.body[item];
     });
 
     req.checkFiles = checkParam(req, function(item) {
@@ -222,7 +222,7 @@ var expressValidator = function(options) {
     }
 
     req.filter = function(param) {
-      return sanitize(this, param, this.param(param));
+      return sanitize(this, param, this.body[param]);
     };
 
     // Create some aliases - might help with code readability


### PR DESCRIPTION
request.param() is deprecated as of 4.11