### PR TITLE
Refactor

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -1,262 +1,245 @@
-/*
- * This binds the node-validator library to the req object so that
- * the validation / sanitization methods can be called on parameter
- * names rather than the actual strings.
+var validator = require('validator');
+var _ = require('lodash');
+
+// validators and sanitizers not prefixed with is/to
+var additionalValidators = ['contains', 'equals', 'matches'];
+var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'stripLow', 'whitelist', 'blacklist', 'normalizeEmail'];
+
+/**
+ * Initalizes a chain of validators
  *
- *
- * 1. To validate parameters, use `req.check(param_name, [err_message])`
- *        e.g. req.check('param1').len(1, 6).isInt();
- *        e.g. req.checkHeader('referer').contains('mydomain.com');
- *
- *    Each call to `check()` will throw an exception by default. To
- *    specify a custom err handler, use `req.onValidationError(errback)`
- *    where errback receives a parameter containing the error message
- *
- * 2. To sanitize parameters, use `req.sanitize(param_name)`
- *        e.g. req.sanitize('param1').toBoolean();
- *        e.g. req.sanitize('param2').toInt();
- *
- * 3. Done! Access your validated and sanitized paramaters through the
- *    `req.params` object
+ * @class
+ * @param  {(string|string[])}  param         path to property to validate
+ * @param  {string}             failMsg       validation failure message
+ * @param  {Request}            req           request to attach validation errors
+ * @param  {string}             location      request property to find value (body, params, query, etc.)
+ * @param  {object}             options       options containing error formatter
  */
 
-var validator = require('validator');
+function ValidatorChain(param, failMsg, req, location, options) {
+  this.errorFormatter = options.errorFormatter;
+  this.param = param;
+  this.value = location ? _.get(req[location], param) : undefined;
+  this.validationErrors = [];
+  this.failMsg = failMsg;
+  this.req = req;
+
+  return this;
+}
+
+
+/**
+ * Initializes a  sanitizers
+ *
+ * @class
+ * @param  {(string|string[])}  param    path to property to sanitize
+ * @param  {[type]}             req             request to sanitize
+ * @param  {[type]}             location        request property to find value
+ */
+
+function Sanitizer(param, req, locations) {
+  this.values = locations.map(function(location) {
+    return _.get(req[location], param);
+  });
+
+  this.req = req;
+  this.param = param;
+  this.locations = locations;
+  return this;
+}
+
+/**
+ * Adds validation methods to request object via express middleware
+ *
+ * @method expressValidator
+ * @param  {object}         options
+ * @return {function}       middleware
+ */
 
 var expressValidator = function(options) {
-  options = options || {};
-
-  var _options = {};
-
-  _options.customValidators = options.customValidators || {};
-  _options.customSanitizers = options.customSanitizers || {};
-
-  _options.errorFormatter = options.errorFormatter || function(param, msg, value) {
-    return {
-      param : param,
-      msg   : msg,
-      value : value
-    };
+  var defaults = {
+    customValidators: {},
+    customSanitizers: {},
+    errorFormatter: function(param, msg, value) {
+      return {
+        param: param,
+        msg: msg,
+        value: value
+      };
+    },
   };
 
-  var sanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'stripLow', 'whitelist',
-  'blacklist', 'normalizeEmail'];
+  _.defaults(options, defaults);
 
-  var sanitize = function(request, param, value) {
-    var methods = {};
+  // _.set validators and sainitizers as prototype methods on corresponding chains
+  _.forEach(validator, function(method, methodName) {
+    if (methodName.match(/^is/) || _.contains(additionalValidators, methodName)) {
+      ValidatorChain.prototype[methodName] = makeValidator(methodName, validator);
+    }
 
-    Object.keys(validator).forEach(function(methodName) {
-      if (methodName.match(/^to/) || sanitizers.indexOf(methodName) !== -1) {
-        methods[methodName] = function() {
-          var args = [value].concat(Array.prototype.slice.call(arguments));
-          var result = validator[methodName].apply(validator, args);
-          request.updateParam(param, result);
-          return result;
-        };
-      }
-    });
-    Object.keys(_options.customSanitizers).forEach(function(customName) {
-      methods[customName] = function() {
-        var args = [value].concat(Array.prototype.slice.call(arguments));
-        var result = _options.customSanitizers[customName].apply(null, args);
-        request.updateParam(param, result);
-        return result;
-      };
-    });
-    return methods;
+    if (methodName.match(/^to/) || _.contains(additionalSanitizers, methodName)) {
+      Sanitizer.prototype[methodName] = makeSanitizer(methodName, validator);
+    }
+  });
+
+  ValidatorChain.prototype.notEmpty = function() {
+    return this.isLength(1);
   };
 
-  function checkParam(req, getter) {
-    return function(param, failMsg) {
+  ValidatorChain.prototype.len = function() {
+    return this.isLength.apply(this, arguments);
+  };
 
-      var value;
+  ValidatorChain.prototype.optional = function() {
+    if (this.value === undefined) {
+      this.skipValidating = true;
+    }
 
-      // If param is not an array, then split by dot notation
-      // returning an array. It will return an array even if
-      // param doesn't have the dot notation.
-      //      'blogpost' = ['blogpost']
-      //      'login.username' = ['login', 'username']
-      // For regex matches you can access the parameters using numbers.
-      if (!Array.isArray(param)) {
-        param = typeof param === 'number' ?
-          [param] :
-          param.split('.').filter(function(e){
-            return e !== '';
-          });
-      }
+    return this;
+  };
 
-      // Extract value from params
-      param.map(function(item) {
-        if (value === undefined) {
-          value = getter(item);
-        } else {
-          value = value[item];
-        }
-      });
-      param = param.join('.');
+  _.forEach(options.customValidators, function(method, customValidatorName) {
+    ValidatorChain.prototype[customValidatorName] = makeValidator(customValidatorName, options.customValidators);
+  });
 
-      var errorHandler = function(msg) {
-        var error = _options.errorFormatter(param, msg, value);
+  _.forEach(options.customSanitizers, function(method, customSanitizerName) {
+    Sanitizer.prototype[customSanitizerName] = makeSanitizer(customSanitizerName, options.customSanitizers);
+  });
 
-        if (req._validationErrors === undefined) {
-          req._validationErrors = [];
-        }
-        req._validationErrors.push(error);
-
-        if (req.onErrorCallback) {
-          req.onErrorCallback(msg);
-        }
-        return this;
-      };
-
-      var methods = [];
-
-      Object.keys(validator).forEach(function(methodName) {
-        if (!methodName.match(/^to/) && sanitizers.indexOf(methodName) === -1) {
-          methods[methodName] = function() {
-            var args = [value].concat(Array.prototype.slice.call(arguments));
-            var isCorrect = validator[methodName].apply(validator, args);
-
-            if (!isCorrect) {
-              errorHandler(failMsg || 'Invalid value');
-            }
-
-            return methods;
-          };
-        }
-      });
-
-      Object.keys(_options.customValidators).forEach(function(customName) {
-        methods[customName] = function() {
-          var args = [value].concat(Array.prototype.slice.call(arguments));
-          var isCorrect = _options.customValidators[customName].apply(null, args);
-
-          if (!isCorrect) {
-            errorHandler(failMsg || 'Invalid value');
-          }
-
-          return methods;
-        };
-      });
-
-      methods['notEmpty'] = function() {
-        return methods.isLength(1);
-      };
-
-      methods['len'] = function() {
-        return methods.isLength.apply(methods.isLength, Array.prototype.slice.call(arguments));
-      };
-
-      methods['optional'] = function() {
-        if (value !== undefined) {
-          return methods;
-        }
-
-        var dummyMethods = [];
-        for (var methodName in methods) {
-          dummyMethods[methodName] = function() { return dummyMethods; };
-        }
-        return dummyMethods;
-      };
-
-      return methods;
-    };
-  }
   return function(req, res, next) {
+    var locations = ['body', 'params', 'query'];
 
-    req.updateParam = function(name, value) {
-      // route params like /user/:id
-      if (this.params && this.params.hasOwnProperty(name) &&
-        undefined !== this.params[name]) {
-        return this.params[name] = value;
-      }
-      // query string params
-      if (undefined !== this.query[name]) {
-        return this.query[name] = value;
-      }
-      // request body params via connect.bodyParser
-      if (this.body && undefined !== this.body[name]) {
-        return this.body[name] = value;
-      }
-      return false;
-    };
-
-    req.check = checkParam(req, function(item) {
-      return param(req, item);
-    });
-
-    req.checkFiles = checkParam(req, function(item) {
-      return req.files && req.files[item];
-    });
-
-    req.checkBody = checkParam(req, function(item) {
-      return req.body && req.body[item];
-    });
-
-    req.checkParams = checkParam(req, function(item) {
-      return req.params && req.params[item];
-    });
-
-    req.checkQuery = checkParam(req, function(item) {
-      return req.query && req.query[item];
-    });
-
-    req.checkHeader = checkParam(req, function(header) {
-      var toCheck;
-
-      if (header === 'referrer' || header === 'referer') {
-        toCheck = req.headers.referer;
-      } else {
-        toCheck = req.headers[header];
-      }
-      return req.headers && toCheck;
-    });
-
-    req.onValidationError = function(errback) {
-      req.onErrorCallback = errback;
-    };
-
+    req._validationErrors = [];
     req.validationErrors = function(mapped) {
-      if (req._validationErrors === undefined) {
-        return null;
-      }
-      if (mapped) {
+      if (mapped && req._validationErrors.length > 0) {
         var errors = {};
         req._validationErrors.forEach(function(err) {
           errors[err.param] = err;
         });
+
         return errors;
       }
-      return req._validationErrors;
+
+      return req._validationErrors.length > 0 ? req._validationErrors : false;
     };
 
-    req.filter = function(item) {
-      return sanitize(this, item, param(req, item));
+    locations.forEach(function(location) {
+      req['sanitize' + _.capitalize(location)] = function(param) {
+        return new Sanitizer(param, req, [location]);
+      };
+    });
+
+    req.sanitize = function(param) {
+      return new Sanitizer(param, req, locations);
     };
 
-    // Create some aliases - might help with code readability
-    req.sanitize = req.filter;
+    locations.forEach(function(location) {
+      req['check' + _.capitalize(location)] = function(param, failMsg) {
+        return new ValidatorChain(param, failMsg, req, location, options);
+      };
+    });
+
+    req.checkFiles = function(param, failMsg) {
+      return new ValidatorChain(param, failMsg, req, 'files', options);
+    };
+
+    req.checkHeaders = function(param, failMsg) {
+      if (param === 'referrer') {
+        param = 'referer';
+      }
+
+      return new ValidatorChain(param, failMsg, req, 'headers', options);
+    };
+
+    req.check = function(param, failMsg) {
+      return new ValidatorChain(param, failMsg, req, locate(req, param), options);
+    };
+
+    req.filter = req.sanitize;
     req.assert = req.check;
     req.validate = req.check;
 
-    // Taken from express 3.x for express 4.x compatibility
-    function param(req, name, defaultValue){
-      // route params like /user/:id
-      if (req.params && req.params.hasOwnProperty(name) && undefined !== req.params[name]) {
-        return req.params[name];
-      }
-      // query string params
-      if (undefined !== req.query[name]) {
-        return req.query[name];
-      }
-      // request body params via connect.bodyParser
-      if (req.body && undefined !== req.body[name]) {
-        return req.body[name];
-      }
-      return defaultValue;
-    }
-
-    return next();
+    next();
   };
 };
+
+/**
+ * Validates and handles errors, return instance of itself to allow for chaining
+ *
+ * @method makeValidator
+ * @param  {string}          methodName
+ * @param  {object}          container
+ * @return {function}
+ */
+
+function makeValidator(methodName, container) {
+  return function() {
+    var args = [];
+    args.push(this.value);
+    args = args.concat(Array.prototype.slice.call(arguments));
+
+    var result = container[methodName].apply(container, args);
+
+    var isValid = this.skipValidating || result;
+
+    if (!isValid) {
+      var error = this.errorFormatter(this.param, this.failMsg || 'Invalid value', this.value);
+      this.validationErrors.push(error);
+      this.req._validationErrors.push(error);
+    }
+
+    return this;
+  };
+}
+
+/**
+ * Sanitizes and sets sanitized value on the request, then return instance of itself to allow for chaining
+ *
+ * @method makeSanitizer
+ * @param  {string}          methodName
+ * @param  {object}          container
+ * @return {function}
+ */
+
+function makeSanitizer(methodName, container) {
+  return function() {
+    var _arguments = arguments;
+    var result;
+    this.values.forEach(function(value, i) {
+      if (value) {
+        var args = [value];
+        args = args.concat(Array.prototype.slice.call(_arguments));
+        result = container[methodName].apply(container, args);
+
+        _.set(this.req[this.locations[i]], this.param, result);
+        this.values[i] = result;
+      }
+    }.bind(this));
+
+    return result;
+  };
+}
+
+/**
+ * find location of param
+ *
+ * @method param
+ * @param  {Request} req       express request object
+ * @param  {(string|string[])} name [description]
+ * @return {string}
+ */
+
+function locate(req, name) {
+  if (_.get(req.params, name)) {
+    return 'params';
+  } else if (_.has(req.query, name)) {
+    return 'query';
+  } else if (_.has(req.body, name)) {
+    return 'body';
+  }
+
+  return undefined;
+}
+
 module.exports = expressValidator;
 module.exports.validator = validator;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "lodash": "3.9.3",
     "validator": "3.39.0"
   },
   "devDependencies": {

--- a/test/nestedInputSanitizeTest.js
+++ b/test/nestedInputSanitizeTest.js
@@ -1,0 +1,40 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  req.sanitize(['user', 'fields', 'email']).trim();
+  res.send( req.body );
+}
+
+function pass(body) {
+  expect(body).to.have.deep.property('user.fields.email', 'test@example.com');
+}
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#nestedInputSanitizers', function() {
+  describe('POST tests', function() {
+
+    it('should return property and sanitized value', function(done) {
+      postRoute('/', { user: { fields: { email: '     test@example.com       ' } } }, pass, done);
+    });
+
+  });
+});

--- a/test/sanitizeBodyTest.js
+++ b/test/sanitizeBodyTest.js
@@ -1,0 +1,55 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  req.sanitizeBody('testparam').whitelist(['a', 'b', 'c']);
+  res.send({ body: req.body });
+}
+
+function pass(body) {
+  expect(body).to.have.deep.property('body.testparam', 'abc');
+}
+function fail(body) {
+  expect(body).to.not.have.property('body', 'testparam');
+}
+
+function getRoute(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#sanitizeBody', function() {
+  describe('POST tests', function() {
+    it('should return property and sanitized value when body param is present', function(done) {
+      postRoute('/', {testparam: '   abcdf    '}, pass, done);
+    });
+
+    it('should not return property when body param is missing', function(done) {
+      postRoute('/', null, fail, done);
+    });
+
+  });
+});

--- a/test/sanitizeParamsTest.js
+++ b/test/sanitizeParamsTest.js
@@ -1,0 +1,65 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  req.sanitizeParams('testparam').whitelist(['a', 'b', 'c']);
+  res.send({ params: req.params });
+}
+
+function pass(body) {
+  expect(body).to.have.deep.property('params.testparam', 'abc');
+}
+function fail(body) {
+  expect(body).to.not.have.property('params', 'testparam');
+}
+
+function getRoute(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#sanitizeParams', function() {
+  describe('GET tests', function() {
+    it('should return property and sanitized value when param is present', function(done) {
+      getRoute('/abcdef', pass, done);
+    });
+    it('should not return property when param is missing', function(done) {
+      getRoute('/', fail, done);
+    });
+
+
+  });
+  describe('POST tests', function() {
+    it('should return property and sanitized value when param is present', function(done) {
+      postRoute('/abcdef', null, pass, done);
+    });
+
+    it('should not return property when param is missing', function(done) {
+      postRoute('/', null, fail, done);
+    });
+
+  });
+});

--- a/test/sanitizeQueryTest.js
+++ b/test/sanitizeQueryTest.js
@@ -1,0 +1,65 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  req.sanitizeQuery('testparam').whitelist(['a', 'b', 'c']);
+  res.send({ query: req.query });
+}
+
+function pass(body) {
+  expect(body).to.have.deep.property('query.testparam', 'abc');
+}
+function fail(body) {
+  expect(body).to.not.have.property('query', 'testparam');
+}
+
+function getRoute(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#sanitizeQuery', function() {
+  describe('GET tests', function() {
+    it('should return property and sanitized value when query param is present', function(done) {
+      getRoute('/?testparam=abcdef', pass, done);
+    });
+    it('should not return property when query param is missing', function(done) {
+      getRoute('/', fail, done);
+    });
+
+
+  });
+  describe('POST tests', function() {
+    it('should return property and sanitized value when query param is present', function(done) {
+      postRoute('/?testparam=abcdef', null, pass, done);
+    });
+
+    it('should not return property when query param is missing', function(done) {
+      postRoute('/', null, fail, done);
+    });
+
+  });
+});

--- a/test/sanitizerResultTest.js
+++ b/test/sanitizerResultTest.js
@@ -1,0 +1,87 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  var body = req.sanitizeBody('testparam').whitelist(['a', 'b', 'c']);
+  var query = req.sanitizeQuery('testparam').whitelist(['a', 'b', 'c']);
+  var params = req.sanitizeParams('testparam').whitelist(['a', 'b', 'c']);
+
+  res.send({ params: params, query: query, body: body });
+}
+
+function pass(body) {
+  if (body.params) {
+    expect(body).to.have.property('params', 'abc');
+  }
+
+  if (body.query) {
+    expect(body).to.have.property('query', 'abc');
+  }
+
+  if (body.body) {
+    expect(body).to.have.property('body', 'abc');
+  }
+
+}
+function fail(body) {
+  expect(body).not.to.have.deep.property('params.testparam');
+  expect(body).not.to.have.deep.property('query.testparam');
+}
+
+function getRoute(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#sanitizers', function() {
+  describe('GET tests', function() {
+    it('should return property and sanitized value when param is present', function(done) {
+      getRoute('/abcdef', pass, done);
+    });
+    it('should not return property when query and param is missing', function(done) {
+      getRoute('/', fail, done);
+    });
+
+    it('should return both query and param and sanitized values when they are both present', function(done) {
+      getRoute('/abcdef?testparam=abcdef', pass, done);
+    });
+
+  });
+  describe('POST tests', function() {
+    it('should return property and sanitized value when param is present', function(done) {
+      postRoute('/abcdef', null, pass, done);
+    });
+
+    it('should return both query and param and sanitized values when they are both present', function(done) {
+      postRoute('/abcdef?testparam=abcdef', { testparam: '    abcdef     ' }, pass, done);
+    });
+
+    it('should return property and sanitized value when body is present', function(done) {
+      postRoute('/', { testparam: '     abcdef     ' }, pass, done);
+    });
+
+  });
+});

--- a/test/sanitizerTest.js
+++ b/test/sanitizerTest.js
@@ -1,0 +1,85 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  req.sanitize('testparam').whitelist(['a', 'b', 'c']);
+  res.send({ params: req.params, query: req.query, body: req.body });
+}
+
+function pass(body) {
+  if (Object.keys(body.params).length) {
+    expect(body).to.have.deep.property('params.testparam', 'abc');
+  }
+
+  if (Object.keys(body.query).length) {
+    expect(body).to.have.deep.property('query.testparam', 'abc');
+  }
+
+  if (Object.keys(body.body).length) {
+    expect(body).to.have.deep.property('body.testparam', 'abc');
+  }
+
+}
+
+function fail(body) {
+  expect(body).not.to.have.deep.property('params.testparam');
+  expect(body).not.to.have.deep.property('query.testparam');
+}
+
+function getRoute(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#sanitizers', function() {
+  describe('GET tests', function() {
+    it('should return property and sanitized value when param is present', function(done) {
+      getRoute('/abcdef', pass, done);
+    });
+    it('should not return property when query and param is missing', function(done) {
+      getRoute('/', fail, done);
+    });
+
+    it('should return both query and param and sanitized values when they are both present', function(done) {
+      getRoute('/abcdef?testparam=abcdef', pass, done);
+    });
+
+  });
+  describe('POST tests', function() {
+    it('should return property and sanitized value when param is present', function(done) {
+      postRoute('/abcdef', null, pass, done);
+    });
+
+    it('should return both query and param and sanitized values when they are both present', function(done) {
+      postRoute('/abcdef?testparam=abcdef', { testparam: '    abcdef     ' }, pass, done);
+    });
+
+    it('should return property and sanitized value when body is present', function(done) {
+      postRoute('/', { testparam: '     abcdef     ' }, pass, done);
+    });
+
+  });
+});


### PR DESCRIPTION
This initially started with just wanting to have sanitisers support nested params, but I found the existing code quite hard to follow, and doing a few odd things. So I ended up changing the whole thing, but all the existing tests pass with some new ones.

The result of all this is... sanitisers support nested params, and are chainable. Added some documentation to the code describing whats going on. And added documentation in README.md

Only one breaking change, in order make sanitisers chainable, to do that I couldn't have the sanitizers return the result directly, to do that now you need to append `.result()`.