### PR TITLE
Add validation by schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,38 @@ Same as [req.check()](#reqcheck), but only looks in `req.query`.
 #### req.checkParams();
 Same as [req.check()](#reqcheck), but only looks in `req.params`.
 
+## Validation By schema
+
+Alternatively you can define all your validations at once using a simple schema. This also enables per-validator error messages.
+Schema validation will be used if you pass an object to any of the validator methods.
+
+```javascript
+req.checkBody({
+  'email': {
+    notEmpty: true,
+    isEmail:
+      errorMessage: 'Invalid Email'
+    }
+  },
+  'password': {
+    notEmpty: true,
+    isLength: {
+      options: [2, 10] // pass options to the valdatior with the options property as an array
+    },
+    errorMessage: 'Invalid Password' // Error message for the parameter
+  },
+  'name.first': { //
+    optional: true, // won't validate if field is empty
+    isLength: {
+      options: [2, 10],
+      errorMessage: 'Must be between 2 and 10 chars long' // Error message for the validator, takes precedent over parameter message
+    },
+    errorMessage: 'Invalid First Name'
+  }
+});
+```
+
+
 ## Validation errors
 
 You have two choices on how to get the validation errors:
@@ -242,44 +274,13 @@ errors:
 ]
 ```
 
-### Optional input
+## Optional input
 
 You can use the `optional()` method to check an input only when the input exists.
 
 ```javascript
 req.checkBody('email').optional().isEmail();
 //if there is no error, req.body.email is either undefined or a valid mail.
-```
-
-### Validation By schema
-
-Alternatively you can define all your validations at once using a simple schema. This also enables per-validator error messages.
-Schema validation will be used if you pass an object to any of the validator methods.
-
-```javascript
-req.checkBody({
-  'email': {
-    notEmpty: true,
-    isEmail:
-      failMsg: 'Invalid Email'
-    }
-  },
-  'password': {
-    notEmpty: true,
-    isLength: {
-      options: [2, 10]
-    },
-    failMsg: 'Invalid Password' // Error message for the parameter
-  },
-  'name.first': { //
-    notEmpty: true,
-    isLength: {
-      options: [2, 10],
-      failMsg: 'Must be between 2 and 10 chars long' // Error message for the validator, takes precedent over parameter message
-    },
-    failMsg: 'Invalid First Name'
-  }
-});
 ```
 
 ## Sanitizer

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ mappedErrors:
 
 ### Per-validation messages
 
-You can provide an error message for a single validation with `.withMessage()`. This can be chained with the rest of your validation, and if you don't use it for one of the validations then it will fall back to the default. 
+You can provide an error message for a single validation with `.withMessage()`. This can be chained with the rest of your validation, and if you don't use it for one of the validations then it will fall back to the default.
 
 ```javascript
 req.assert('email', 'Invalid email')
@@ -249,6 +249,37 @@ You can use the `optional()` method to check an input only when the input exists
 ```javascript
 req.checkBody('email').optional().isEmail();
 //if there is no error, req.body.email is either undefined or a valid mail.
+```
+
+### Validation By schema
+
+Alternatively you can define all your validations at once using a simple schema. This also enables per-validator error messages.
+Schema validation will be used if you pass an object to any of the validator methods.
+
+```javascript
+req.checkBody({
+  'email': {
+    notEmpty: true,
+    isEmail:
+      failMsg: 'Invalid Email'
+    }
+  },
+  'password': {
+    notEmpty: true,
+    isLength: {
+      options: [2, 10]
+    },
+    failMsg: 'Invalid Password' // Error message for the parameter
+  },
+  'name.first': { //
+    notEmpty: true,
+    isLength: {
+      options: [2, 10],
+      failMsg: 'Must be between 2 and 10 chars long' // Error message for the validator, takes precedent over parameter message
+    },
+    failMsg: 'Invalid First Name'
+  }
+});
 ```
 
 ## Sanitizer

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -136,6 +136,9 @@ var expressValidator = function(options) {
 
     locations.forEach(function(location) {
       req['check' + _.capitalize(location)] = function(param, failMsg) {
+        if(_.isPlainObject(param)) {
+          return validateSchema(param, req, location, options);
+        }
         return new ValidatorChain(param, failMsg, req, location, options);
       };
     });
@@ -153,6 +156,9 @@ var expressValidator = function(options) {
     };
 
     req.check = function(param, failMsg) {
+      if(_.isPlainObject(param)) {
+        return validateSchema(param, req, param, options);
+      }
       return new ValidatorChain(param, failMsg, req, locate(req, param), options);
     };
 
@@ -163,6 +169,29 @@ var expressValidator = function(options) {
     next();
   };
 };
+
+/**
+ * validate an object using a schema
+ *
+ * @method validateParams
+ * @param  {Object}       schema    schema of validations
+ * @param  {Request}      req       request to attach validation errors
+ * @param  {string}       location  request property to find value (body, params, query, etc.)
+ * @param  {Object}       options   options containing custom validators & errorFormatter
+ * @return {object[]}               array of errors
+ */
+
+function validateSchema(schema, req, loc, options) {
+  for(var param in schema) {
+    for(var methodName in schema[param]) {
+      var failMsg = schema[param][methodName].failMsg || 'Invalid param';
+
+      var validator = new ValidatorChain(param, failMsg, req, locate(req, param), options);
+
+      validator[methodName].apply(validator, schema[param][methodName].options);
+    }
+  }
+}
 
 /**
  * Validates and handles errors, return instance of itself to allow for chaining

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -216,11 +216,11 @@ function validateSchema(schema, req, loc, options) {
   for (var param in schema) {
     loc = loc === 'any' ? locate(req, param) : loc;
     var validator = new ValidatorChain(param, null, req, loc, options);
-    var paramFailMsg = schema[param].failMsg;
-    delete schema[param].failMsg;
+    var paramErrorMessage = schema[param].errorMessage;
+    delete schema[param].errorMessage;
 
     for (var methodName in schema[param]) {
-      validator.failMsg = schema[param][methodName].failMsg || paramFailMsg || 'Invalid param';
+      validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
       validator[methodName].apply(validator, schema[param][methodName].options);
     }
   }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -149,7 +149,7 @@ var expressValidator = function(options) {
 
     locations.forEach(function(location) {
       req['check' + _.capitalize(location)] = function(param, failMsg) {
-        if(_.isPlainObject(param)) {
+        if (_.isPlainObject(param)) {
           return validateSchema(param, req, location, options);
         }
         return new ValidatorChain(param, failMsg, req, location, options);
@@ -169,7 +169,7 @@ var expressValidator = function(options) {
     };
 
     req.check = function(param, failMsg) {
-      if(_.isPlainObject(param)) {
+      if (_.isPlainObject(param)) {
         return validateSchema(param, req, 'any', options);
       }
       return new ValidatorChain(param, failMsg, req, locate(req, param), options);
@@ -184,7 +184,25 @@ var expressValidator = function(options) {
 };
 
 /**
- * validate an object using a schema
+ * validate an object using a schema, using following format:
+ *
+ * {
+ *   paramName: {
+ *     validatorName: true,
+ *     validator2Name: true
+ *   }
+ * }
+ *
+ * Pass options or a custom error message:
+ *
+ * {
+ *   paramName: {
+ *     validatorName: {
+ *       options: ['', ''],
+ *       errorMessage: 'An Error Message'
+ *     }
+ *   }
+ * }
  *
  * @method validateParams
  * @param  {Object}       schema    schema of validations
@@ -195,12 +213,14 @@ var expressValidator = function(options) {
  */
 
 function validateSchema(schema, req, loc, options) {
-  for(var param in schema) {
-    loc = (loc === 'any') ? locate(req, param) : loc;
+  for (var param in schema) {
+    loc = loc === 'any' ? locate(req, param) : loc;
     var validator = new ValidatorChain(param, null, req, loc, options);
+    var paramFailMsg = schema[param].failMsg;
+    delete schema[param].failMsg;
 
-    for(var methodName in schema[param]) {
-      validator.failMsg = schema[param][methodName].failMsg || 'Invalid param';
+    for (var methodName in schema[param]) {
+      validator.failMsg = schema[param][methodName].failMsg || paramFailMsg || 'Invalid param';
       validator[methodName].apply(validator, schema[param][methodName].options);
     }
   }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -157,7 +157,7 @@ var expressValidator = function(options) {
 
     req.check = function(param, failMsg) {
       if(_.isPlainObject(param)) {
-        return validateSchema(param, req, param, options);
+        return validateSchema(param, req, 'any', options);
       }
       return new ValidatorChain(param, failMsg, req, locate(req, param), options);
     };
@@ -183,11 +183,11 @@ var expressValidator = function(options) {
 
 function validateSchema(schema, req, loc, options) {
   for(var param in schema) {
+    loc = (loc === 'any') ? locate(req, param) : loc;
+    var validator = new ValidatorChain(param, null, req, loc, options);
+
     for(var methodName in schema[param]) {
-      var failMsg = schema[param][methodName].failMsg || 'Invalid param';
-
-      var validator = new ValidatorChain(param, failMsg, req, locate(req, param), options);
-
+      validator.failMsg = schema[param][methodName].failMsg || 'Invalid param';
       validator[methodName].apply(validator, schema[param][methodName].options);
     }
   }

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -60,7 +60,7 @@ before(function() {
   app = require('./helpers/app')(validation);
 });
 
-describe('#bodyValidations()', function() {
+describe('#checkBodySchema()', function() {
   describe('GET tests', function() {
     it('should return three errors when param is missing', function(done) {
       getRoute('/', fail, 3, done);

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -10,7 +10,7 @@ function validation(req, res) {
   req.checkBody({
     'testparam': {
       notEmpty: true,
-      isInt: true,
+      isInt: true
     },
     'arrayParam': {
       isArray: true

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -1,0 +1,117 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var errorMessage = 'Invalid param';
+
+var app;
+
+function validation(req, res) {
+  req.checkBody({
+    'testparam': {
+      notEmpty: true,
+      isInt: true,
+    },
+    'arrayParam': {
+      isArray: true
+    }
+  });
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+
+  res.send({ testparam: req.body.testparam });
+}
+
+function fail(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('testparam', '42');
+}
+
+function getRoute(path, test, length, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+function postRoute(path, data, test, length, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#bodyValidations()', function() {
+  describe('GET tests', function() {
+    it('should return three errors when param is missing', function(done) {
+      getRoute('/', fail, 3, done);
+    });
+
+    it('should return three errors when param is present, but not in the body', function(done) {
+      getRoute('/42', fail, 3, done);
+    });
+  });
+
+  describe('POST tests', function() {
+    it('should return three errors when param is missing', function(done) {
+      postRoute('/', null, fail, 3, done);
+    });
+
+    it('should return three errors when param is present, but not in the body', function(done) {
+      postRoute('/42', null, fail, 3, done);
+    });
+
+    // POST only
+
+    it('should return three errors when params are not present', function(done) {
+      postRoute('/test?testparam=gettest', null, fail, 3, done);
+    });
+
+    it('should return three errors when param is present, but not in body', function(done) {
+      postRoute('/42?testparam=42', null, fail, 3, done);
+    });
+
+    it('should return two errors when one param is present, but does not validate', function(done) {
+      postRoute('/42?testparam=42', { testparam: 'posttest' }, fail, 2, done);
+    });
+
+    it('should return a success when params validate on the body', function(done) {
+      postRoute('/?testparam=blah', { testparam: '42', arrayParam: [1, 2, 3] }, pass, null, done);
+    });
+
+    it('should return two errors when two params are present, but do not validate', function(done) {
+      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: 123 }, fail, 2, done);
+    });
+
+    it('should return two errors when two params are present, but do not validate', function(done) {
+      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: {} }, fail, 2, done);
+    });
+
+    it('should return two errors when two params are present, but do not validate', function(done) {
+      postRoute('/', { testparam: 'test', arrayParam: '[]' }, fail, 2, done);
+    });
+
+    it('should return a success when params validate on the body', function(done) {
+      postRoute('/', { testparam: '42', arrayParam: [] }, pass, null, done);
+    });
+  });
+});

--- a/test/checkParamsSchemaTest.js
+++ b/test/checkParamsSchemaTest.js
@@ -1,0 +1,132 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not an integer';
+
+// There are three ways to pass parameters to express:
+// - as part of the URL
+// - as GET parameter in the querystring
+// - as POST parameter in the body
+// These test show that req.checkParams are only interested in req.params values, all other
+// parameters will be ignored.
+
+function validation(req, res) {
+  req.checkParams({
+    'testparam': {
+      notEmpty: true,
+      isInt: {
+        failMsg: 'Parameter is not an integer'
+      },
+    },
+  });
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({ testparam: req.params.testparam });
+}
+
+function fail(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function failMulti(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', 'Invalid param');
+  expect(body[1]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('testparam', '42');
+}
+
+function getRoute(path, test, length, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+function postRoute(path, data, test, length, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#checkParams()', function() {
+  describe('GET tests', function() {
+    it('should return one error when param does not validate as int', function(done) {
+      getRoute('/test', fail, 1, done);
+    });
+
+    it('should return two errors when param is missing', function(done) {
+      getRoute('/', failMulti, 2, done);
+    });
+
+    it('should return a success when param validates', function(done) {
+      getRoute('/42', pass, null, done);
+    });
+
+    it('should return a success when param validates and unrelated query is present', function(done) {
+      getRoute('/42?testparam=42', pass, null, done);
+    });
+
+    it('should return one error when param does not validate as int and unrelated query is present', function(done) {
+      getRoute('/test?testparam=blah', fail, 1, done);
+    });
+  });
+
+  describe('POST tests', function() {
+    it('should return one error when param does not validate as int', function(done) {
+      postRoute('/test', null, fail, 1, done);
+    });
+
+    it('should return two errors when param is missing', function(done) {
+      postRoute('/', null, failMulti, 2, done);
+    });
+
+    it('should return a success when param validates', function(done) {
+      postRoute('/42', null, pass, null, done);
+    });
+
+    it('should return a success when param validates and unrelated query is present', function(done) {
+      postRoute('/42?testparam=42', null, pass, null, done);
+    });
+
+    it('should return one error when param does not validate as int and unrelated query is present', function(done) {
+      postRoute('/test?testparam=blah', null, fail, 1, done);
+    });
+
+    // POST only
+
+    it('should return a success when param validates and unrelated query/body is present', function(done) {
+      postRoute('/42?testparam=blah', { testparam: 'posttest' }, pass, null, done);
+    });
+
+    it('should return one error when param does not validate as int and unrelated query/body is present', function(done) {
+      postRoute('/test?testparam=blah', { testparam: 'posttest' }, fail, 1, done);
+    });
+
+    it('should return two errors when param is missing and unrelated query/body is present', function(done) {
+      postRoute('/?testparam=blah', { testparam: 'posttest' }, failMulti, 2, done);
+    });
+  });
+
+});

--- a/test/checkParamsSchemaTest.js
+++ b/test/checkParamsSchemaTest.js
@@ -18,8 +18,8 @@ function validation(req, res) {
       notEmpty: true,
       isInt: {
         failMsg: 'Parameter is not an integer'
-      },
-    },
+      }
+    }
   });
 
   var errors = req.validationErrors();

--- a/test/checkParamsSchemaTest.js
+++ b/test/checkParamsSchemaTest.js
@@ -70,7 +70,7 @@ before(function() {
   app = require('./helpers/app')(validation);
 });
 
-describe('#checkParams()', function() {
+describe('#checkParamsSchema()', function() {
   describe('GET tests', function() {
     it('should return one error when param does not validate as int', function(done) {
       getRoute('/test', fail, 1, done);

--- a/test/checkParamsSchemaTest.js
+++ b/test/checkParamsSchemaTest.js
@@ -17,7 +17,7 @@ function validation(req, res) {
     'testparam': {
       notEmpty: true,
       isInt: {
-        failMsg: 'Parameter is not an integer'
+        errorMessage: 'Parameter is not an integer'
       }
     }
   });

--- a/test/checkQuerySchemaTest.js
+++ b/test/checkQuerySchemaTest.js
@@ -16,7 +16,7 @@ function validation(req, res) {
   req.checkQuery({
     'testparam': {
       notEmpty: true,
-      failMsg: errorMessage,
+      errorMessage: errorMessage,
       isInt: true
     }
   });

--- a/test/checkQuerySchemaTest.js
+++ b/test/checkQuerySchemaTest.js
@@ -3,7 +3,7 @@ var expect = chai.expect;
 var request = require('supertest');
 
 var app;
-var errorMessage = 'Parameter is not an integer';
+var errorMessage = 'Parameter is not valid';
 
 // There are three ways to pass parameters to express:
 // - as part of the URL
@@ -16,10 +16,9 @@ function validation(req, res) {
   req.checkQuery({
     'testparam': {
       notEmpty: true,
-      isInt: {
-        failMsg: 'Parameter is not an integer'
-      },
-    },
+      failMsg: errorMessage,
+      isInt: true
+    }
   });
 
   var errors = req.validationErrors();
@@ -36,7 +35,7 @@ function fail(body, length) {
 
 function failMulti(body, length) {
   expect(body).to.have.length(length);
-  expect(body[0]).to.have.property('msg', 'Invalid param');
+  expect(body[0]).to.have.property('msg', errorMessage);
   expect(body[1]).to.have.property('msg', errorMessage);
 }
 

--- a/test/checkQuerySchemaTest.js
+++ b/test/checkQuerySchemaTest.js
@@ -70,7 +70,7 @@ before(function() {
   app = require('./helpers/app')(validation);
 });
 
-describe('#checkQuery()', function() {
+describe('#checkQuerySchema()', function() {
   describe('GET tests', function() {
     it('should return two errors when query is missing, and unrelated param is present', function(done) {
       getRoute('/test', failMulti, 2, done);

--- a/test/checkQuerySchemaTest.js
+++ b/test/checkQuerySchemaTest.js
@@ -1,0 +1,124 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not an integer';
+
+// There are three ways to pass parameters to express:
+// - as part of the URL
+// - as GET parameter in the querystring
+// - as POST parameter in the body
+// These test show that req.checkQuery are only interested in req.query values, all other
+// parameters will be ignored.
+
+function validation(req, res) {
+  req.checkQuery({
+    'testparam': {
+      notEmpty: true,
+      isInt: {
+        failMsg: 'Parameter is not an integer'
+      },
+    },
+  });
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({ testparam: req.query.testparam });
+}
+
+function fail(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function failMulti(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', 'Invalid param');
+  expect(body[1]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('testparam', '42');
+}
+
+function getRoute(path, test, length, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+function postRoute(path, data, test, length, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#checkQuery()', function() {
+  describe('GET tests', function() {
+    it('should return two errors when query is missing, and unrelated param is present', function(done) {
+      getRoute('/test', failMulti, 2, done);
+    });
+
+    it('should return two errors when query is missing', function(done) {
+      getRoute('/', failMulti, 2, done);
+    });
+
+    it('should return a success when query validates and unrelated query is present', function(done) {
+      getRoute('/42?testparam=42', pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated query is present', function(done) {
+      getRoute('/test?testparam=blah', fail, 1, done);
+    });
+  });
+
+  describe('POST tests', function() {
+    it('should return two errors when query is missing, and unrelated param is present', function(done) {
+      postRoute('/test', null, failMulti, 2, done);
+    });
+
+    it('should return two errors when query is missing', function(done) {
+      postRoute('/', null, failMulti, 2, done);
+    });
+
+    it('should return a success when query validates and unrelated query is present', function(done) {
+      postRoute('/42?testparam=42', null, pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated query is present', function(done) {
+      postRoute('/test?testparam=blah', null, fail, 1, done);
+    });
+
+    // POST only
+
+    it('should return a success when query validates and unrelated param/body is present', function(done) {
+      postRoute('/test?testparam=42', { testparam: 'posttest' }, pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated param/body is present', function(done) {
+      postRoute('/test?testparam=blah', { testparam: '42' }, fail, 1, done);
+    });
+
+    it('should return two errors when query is missing and unrelated body is present', function(done) {
+      postRoute('/', { testparam: '42' }, failMulti, 2, done);
+    });
+  });
+
+});

--- a/test/optionalSchemaTest.js
+++ b/test/optionalSchemaTest.js
@@ -10,7 +10,7 @@ function validation(req, res) {
     'optional_param': {
       optional: true,
       isInt: {
-        failMsg: errorMessage
+        errorMessage: errorMessage
       }
     }
   });

--- a/test/optionalSchemaTest.js
+++ b/test/optionalSchemaTest.js
@@ -34,7 +34,7 @@ function pass(body) {
 function testRoute(path, test, done) {
   request(app)
     .get(path)
-    .end(function(err, res){
+    .end(function(err, res) {
       test(res.body);
       done();
     });

--- a/test/optionalSchemaTest.js
+++ b/test/optionalSchemaTest.js
@@ -1,0 +1,79 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not an integer';
+
+function validation(req, res) {
+  req.assert({
+    'optional_param': {
+      optional: true,
+      isInt: {
+        failMsg: errorMessage
+      }
+    }
+  });
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({ result: 'OK' });
+}
+
+function fail(body) {
+  expect(body).to.have.length(1);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('result', 'OK');
+}
+
+function testRoute(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res){
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+// TODO: Don't know if all of these are necessary, but we do need to test body and header
+describe('#optional()', function() {
+  it('should return a success when there is an empty route', function(done) {
+    testRoute('/', pass, done);
+  });
+
+  it('should return a success when there are no params on a route', function(done) {
+    testRoute('/path', pass, done);
+  });
+
+  it('should return a success when the non-optional param is present', function(done) {
+    testRoute('/path?other_param=test', pass, done);
+  });
+
+  it('should return an error when param is provided, but empty', function(done) {
+    testRoute('/path?optional_param', fail, done);
+  });
+
+  it('should return an error when param is provided with equals sign, but empty', function(done) {
+    testRoute('/path?optional_param=', fail, done);
+  });
+
+  it('should return an error when param is provided, but fails validation', function(done) {
+    testRoute('/path?optional_param=test', fail, done);
+  });
+
+  it('should return a success when param is provided and validated', function(done) {
+    testRoute('/path?optional_param=123', pass, done);
+  });
+});


### PR DESCRIPTION
I've added the functionality to be able to validate by passing an object schema to check, checkBody etc. as an alternative to chaining.

example:
````javascript
req.checkBody({
  'email': {
    notEmpty: true,
    isEmail:
      failMsg: 'Invalid Email'
    }
  },
  'password': {
     notEmpty: true
  },
  'name.first': {
    notEmpty: true,
    isLength: {
      options: [2, 10],
      failMsg: 'Must be between 2 and 10 chars long'
    }
  }
});
````
passing true will use the default error message.