### PR TITLE
Test for falsy values in sanitization.

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -207,7 +207,7 @@ function makeSanitizer(methodName, container) {
     var _arguments = arguments;
     var result;
     this.values.forEach(function(value, i) {
-      if (value) {
+      if (value != null) {
         var args = [value];
         args = args.concat(Array.prototype.slice.call(_arguments));
         result = container[methodName].apply(container, args);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "./index.js",
   "scripts": {
-    "test": "mocha ./test",
+    "test": "mocha",
     "jshint": "jshint ./test ./lib",
     "jscs": "jscs ./test ./lib",
     "travis-build": "npm test && npm run jshint && npm run jscs",

--- a/test/sanitizerTest.js
+++ b/test/sanitizerTest.js
@@ -4,6 +4,9 @@ var request = require('supertest');
 
 var app;
 function validation(req, res) {
+  req.sanitize('zerotest').toString();
+  req.sanitize('emptystrtest').toBoolean();
+  req.sanitize('falsetest').toString();
   req.sanitize('testparam').whitelist(['a', 'b', 'c']);
   res.send({ params: req.params, query: req.query, body: req.body });
 }
@@ -19,6 +22,18 @@ function pass(body) {
 
   if (Object.keys(body.body).length) {
     expect(body).to.have.deep.property('body.testparam', 'abc');
+  }
+
+  if (body.body.hasOwnProperty('zerotest')) {
+    expect(body).to.have.deep.property('body.zerotest', '0');
+  }
+
+  if (body.body.hasOwnProperty('emptystrtest')) {
+    expect(body).to.have.deep.property('body.emptystrtest', false);
+  }
+
+  if (body.body.hasOwnProperty('falsetest')) {
+    expect(body).to.have.deep.property('body.falsetest', 'false');
   }
 
 }
@@ -79,6 +94,10 @@ describe('#sanitizers', function() {
 
     it('should return property and sanitized value when body is present', function(done) {
       postRoute('/', { testparam: '     abcdef     ' }, pass, done);
+    });
+
+    it('should return properly sanitized values even if the original value is falsey, but not null/undefined', function(done) {
+      postRoute('/', { testparam: '     abcdef     ', zerotest: 0, emptystrtest: '', falsetest: false }, pass, done);
     });
 
   });


### PR DESCRIPTION
When sanitizing, it was ignoring '', false, and 0. Changed to only ignore null and undefined. Should fix #148.