### PR TITLE
#126 - Added withMessage method to provide a message per validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,25 @@ mappedErrors:
 }
 ```
 
+### Per-validation messages
+
+You can provide an error message for a single validation with `.withMessage()`. This can be chained with the rest of your validation, and if you don't use it for one of the validations then it will fall back to the default. 
+
+```javascript
+req.assert('email', 'Invalid email')
+    .notEmpty().withMessage('Email is required')
+    .isEmail();
+var errors = req.validationErrors();
+```
+errors:
+
+```javascript
+[
+  {param: 'email', msg: 'Email is required', value: '<received input>'}
+  {param: 'email', msg: 'Invalid Email', value: '<received input>'}
+]
+```
+
 ### Optional input
 
 You can use the `optional()` method to check an input only when the input exists.

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -23,7 +23,7 @@ function ValidatorChain(param, failMsg, req, location, options) {
   this.validationErrors = [];
   this.failMsg = failMsg;
   this.req = req;
-  this.lastError = undefined; // used by withMessage to get the values of the last error
+  this.lastError = null; // used by withMessage to get the values of the last error
   return this;
 }
 
@@ -100,13 +100,13 @@ var expressValidator = function(options) {
   };
 
   ValidatorChain.prototype.withMessage = function(message) {
-    if (!!this.lastError) {
-      var error = this.validationErrors.pop();
+    if (this.lastError) {
+      this.validationErrors.pop();
       this.req._validationErrors.pop();
-      error = this.errorFormatter(this.lastError.param, message, this.lastError.value);
+      var error = this.errorFormatter(this.lastError.param, message, this.lastError.value);
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
-      this.lastError = undefined;
+      this.lastError = null;
     }
 
     return this;

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -23,7 +23,7 @@ function ValidatorChain(param, failMsg, req, location, options) {
   this.validationErrors = [];
   this.failMsg = failMsg;
   this.req = req;
-
+  this.lastError = undefined; // used by withMessage to get the values of the last error
   return this;
 }
 
@@ -94,6 +94,19 @@ var expressValidator = function(options) {
   ValidatorChain.prototype.optional = function() {
     if (this.value === undefined) {
       this.skipValidating = true;
+    }
+
+    return this;
+  };
+
+  ValidatorChain.prototype.withMessage = function(message) {
+    if (!!this.lastError) {
+      var error = this.validationErrors.pop();
+      this.req._validationErrors.pop();
+      error = this.errorFormatter(this.lastError.param, message, this.lastError.value);
+      this.validationErrors.push(error);
+      this.req._validationErrors.push(error);
+      this.lastError = undefined;
     }
 
     return this;
@@ -188,6 +201,7 @@ function makeValidator(methodName, container) {
       var error = this.errorFormatter(this.param, this.failMsg || 'Invalid value', this.value);
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
+      this.lastError = { param: this.param, value: this.value };
     }
 
     return this;

--- a/test/withMessageTest.js
+++ b/test/withMessageTest.js
@@ -1,0 +1,75 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Default error message';
+var mustBeTwoDigitsMessage = 'testparam must have two digits';
+var mustBeIntegerMessage = 'testparam must be an integer';
+
+function validation(req, res) {
+  req.checkParams('testparam', errorMessage)
+    .notEmpty()
+    .isInt().withMessage(mustBeIntegerMessage)
+    .isInt() // with default message
+    .isLength(2, 2).withMessage(mustBeTwoDigitsMessage);
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({ testparam: req.params.testparam });
+}
+
+function fail(expectedMessage) {
+  if (Array.isArray(expectedMessage)) {
+    return function(body, length) {
+      expect(body).to.have.length(length);
+      expect(expectedMessage).to.have.length(length);
+      for (var i = 0; i < length; ++i) {
+        expect(body[i]).to.have.property('msg', expectedMessage[i]);
+      }
+    };
+  }
+  return function(body, length) {
+    expect(body).to.have.length(length);
+    expect(body[0]).to.have.property('msg', expectedMessage);
+  };
+}
+
+function pass(body) {
+  expect(body).to.have.property('testparam', '42');
+}
+
+function getRoute(path, test, length, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#withMessage()', function() {
+    it('should return one error per validation when param does not validate as two digit int, with custom message', function(done) {
+      getRoute('/test', fail([mustBeIntegerMessage, errorMessage, mustBeTwoDigitsMessage]), 3, done);
+    });
+
+    it('should return three errors when param is missing, with default message for the first and custom messages for the rest', function(done) {
+      getRoute('/', fail([errorMessage, mustBeIntegerMessage, errorMessage, mustBeTwoDigitsMessage]), 4, done);
+    });
+
+    it('should return a success when param validates', function(done) {
+      getRoute('/42', pass, null, done);
+    });
+
+    it('should return a fail with a single custom message when failing one validiation', function(done) {
+      getRoute('/199', fail(mustBeTwoDigitsMessage), 1, done);
+    });
+});

--- a/test/withMessageTest.js
+++ b/test/withMessageTest.js
@@ -9,7 +9,7 @@ var mustBeIntegerMessage = 'testparam must be an integer';
 
 function validation(req, res) {
   req.checkParams('testparam', errorMessage)
-    .notEmpty()
+    .notEmpty() // with default message
     .isInt().withMessage(mustBeIntegerMessage)
     .isInt() // with default message
     .isLength(2, 2).withMessage(mustBeTwoDigitsMessage);
@@ -57,11 +57,11 @@ before(function() {
 });
 
 describe('#withMessage()', function() {
-    it('should return one error per validation when param does not validate as two digit int, with custom message', function(done) {
+    it('should return one error per validation failure, with custom message where defined', function(done) {
       getRoute('/test', fail([mustBeIntegerMessage, errorMessage, mustBeTwoDigitsMessage]), 3, done);
     });
 
-    it('should return three errors when param is missing, with default message for the first and custom messages for the rest', function(done) {
+    it('should return four errors when param is missing, with default message for the first and third errors, and custom messages for the rest, as defined', function(done) {
       getRoute('/', fail([errorMessage, mustBeIntegerMessage, errorMessage, mustBeTwoDigitsMessage]), 4, done);
     });
 
@@ -69,7 +69,7 @@ describe('#withMessage()', function() {
       getRoute('/42', pass, null, done);
     });
 
-    it('should return a fail with a single custom message when failing one validiation', function(done) {
+    it('should provide a custom message when an invalid value is provided, and the validation is followed by withMessage', function(done) {
       getRoute('/199', fail(mustBeTwoDigitsMessage), 1, done);
     });
 });


### PR DESCRIPTION
Currently, when validations are chained, only a single message to be used for all errors in the chain can be provided. This PR adds a method `.withMessage(message)`, to be called immediately after the validation in the chain, that provides the new message via the errorFormatter. 

In this example:
```javascript
req.check('param', 'Default Message')
    .notEmpty()
    .isInt().withMessage('Custom message')
```

if 'param' is empty, the message 'Default Message' will be used, but if it is provided and is not an integer, 'Custom Message' will be used instead. 

The implementation is simple enough - just track the param & value of the last error generated and then when `withMessage` is called, pop the last error and re-generate it with the new message. 

Tests provided, any feedback welcome.