### PR TITLE
Fixed bug where custom messages would be applied incorrectly

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -202,6 +202,8 @@ function makeValidator(methodName, container) {
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
       this.lastError = { param: this.param, value: this.value };
+    } else {
+      this.lastError = null;
     }
 
     return this;

--- a/test/withMessageTest.js
+++ b/test/withMessageTest.js
@@ -72,4 +72,22 @@ describe('#withMessage()', function() {
     it('should provide a custom message when an invalid value is provided, and the validation is followed by withMessage', function(done) {
       getRoute('/199', fail(mustBeTwoDigitsMessage), 1, done);
     });
+
+    it('should update the error message only if the preceeding validation was the one to fail', function() {
+      var validator = require('../lib/express_validator')();
+      var req = {
+        body: {
+          testParam: 'abc'
+        }
+      };
+
+      validator(req, {}, function() {});
+      req.check('testParam', 'Default Error Message')
+        .isInt() // should produce 'Default Error Message'
+        .isLength(2).withMessage('Custom Error Message');
+
+      expect(req.validationErrors()).to.deep.equal([
+        { param: 'testParam', msg: 'Default Error Message', value: 'abc' }
+      ]);
+    });
 });


### PR DESCRIPTION
Currently, if in a chained validation one validation fails, and no withMessage is provided, but all further validations pass and a with message is provided, the original error will be given the custom message incorrectly. 

This PR fixes this issue, by ensuring that if a validation passes no calls to withMessage further down the chain will attempt to update the error message. 

Test included, feedback welcome.