### PR TITLE
Async Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,35 @@ Same as [req.check()](#reqcheck), but only looks in `req.query`.
 #### req.checkParams();
 Same as [req.check()](#reqcheck), but only looks in `req.params`.
 
+## Asynchronous Validation
+
+If you need to perform asynchronous validation, for example checking a database if a username has been taken already, your custom validator can return a promise.
+
+You **MUST** use `asyncValidationErrors` which returns a promise to check for errors, otherwise the validator promises won't be resolved.
+
+ *`asyncValidationErrors` will also return any regular synchronous validation errors.*
+
+ ```javascript
+app.use(expressValidator({
+  customValidators: {
+    isUsernameAvailable: function(username) {
+      return new Promise(function(resolve, reject) {
+        ...
+      });
+    }
+  }
+}));
+
+...
+
+req.check('username', 'Username Taken').isUsernameAvailable();
+
+req.asyncValidationErrors().catch(function(errors) {
+  res.send(errors);
+});
+
+ ```
+
 ## Validation errors
 
 You have two choices on how to get the validation errors:
@@ -192,8 +221,8 @@ req.assert('email', 'required').notEmpty();
 req.assert('email', 'valid email required').isEmail();
 req.assert('password', '6 to 20 characters required').len(6, 20);
 
-var errors = req.validationErrors();
-var mappedErrors = req.validationErrors(true);
+var errors = req.validationErrors(); // Or req.asyncValidationErrors();
+var mappedErrors = req.validationErrors(true); // Or req.asyncValidationErrors(true);
 ```
 
 errors:
@@ -225,7 +254,7 @@ mappedErrors:
 
 ### Per-validation messages
 
-You can provide an error message for a single validation with `.withMessage()`. This can be chained with the rest of your validation, and if you don't use it for one of the validations then it will fall back to the default. 
+You can provide an error message for a single validation with `.withMessage()`. This can be chained with the rest of your validation, and if you don't use it for one of the validations then it will fall back to the default.
 
 ```javascript
 req.assert('email', 'Invalid email')

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -1,5 +1,6 @@
 var validator = require('validator');
 var _ = require('lodash');
+var Promise = require('bluebird');
 
 // validators and sanitizers not prefixed with is/to
 var additionalValidators = ['contains', 'equals', 'matches'];
@@ -124,7 +125,12 @@ var expressValidator = function(options) {
     var locations = ['body', 'params', 'query'];
 
     req._validationErrors = [];
-    req.validationErrors = function(mapped) {
+    req._asyncValidationErrors = [];
+    req.validationErrors = function(mapped, promisesResolved) {
+      if (!promisesResolved && req._asyncValidationErrors.length > 0) {
+        console.warn('WARNING: You have asynchronus validators but you have not used asyncValidateErrors to check for errors.');
+      }
+
       if (mapped && req._validationErrors.length > 0) {
         var errors = {};
         req._validationErrors.forEach(function(err) {
@@ -135,6 +141,23 @@ var expressValidator = function(options) {
       }
 
       return req._validationErrors.length > 0 ? req._validationErrors : false;
+    };
+
+    req.asyncValidationErrors = function(mapped) {
+      return new Promise(function(resolve, reject) {
+        var promises = req._asyncValidationErrors;
+        Promise.settle(promises).then(function(results) {
+
+          results.forEach(function(result) {
+             if (result.isRejected()) { req._validationErrors.push(result.reason()); }
+          });
+
+          if (req._validationErrors.length > 0) {
+            return reject(req.validationErrors(mapped, true));
+          }
+          resolve();
+        });
+      });
     };
 
     locations.forEach(function(location) {
@@ -197,8 +220,17 @@ function makeValidator(methodName, container) {
     args = args.concat(Array.prototype.slice.call(arguments));
 
     var isValid = container[methodName].apply(container, args);
+
+    var error = this.errorFormatter(this.param, this.failMsg || 'Invalid value', this.value);
+
+    if (isValid.then) {
+      var promise = isValid.catch(function() {
+        return Promise.reject(error);
+      });
+      this.req._asyncValidationErrors.push(promise);
+    }
+
     if (!isValid) {
-      var error = this.errorFormatter(this.param, this.failMsg || 'Invalid value', this.value);
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
       this.lastError = { param: this.param, value: this.value };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "bluebird": "^2.9.x",
     "lodash": "3.10.x",
     "validator": "4.0.x"
   },

--- a/test/asyncTest.js
+++ b/test/asyncTest.js
@@ -1,0 +1,111 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not 42';
+
+// There are three ways to pass parameters to express:
+// - as part of the URL
+// - as GET parameter in the querystring
+// - as POST parameter in the body
+// These test show that req.checkQuery are only interested in req.query values, all other
+// parameters will be ignored.
+
+function validation(req, res) {
+  req.checkQuery('testparam', errorMessage).notEmpty().isAsyncTest();
+
+  req.asyncValidationErrors().then(function() {
+    res.send({ testparam: req.query.testparam });
+  }, function(errors) {
+    return res.send(errors);
+  });
+}
+
+function fail(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('testparam', '42');
+}
+
+function getRoute(path, test, length, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+function postRoute(path, data, test, length, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#asyncTest()', function() {
+  describe('GET tests', function() {
+    it('should return two errors when query is missing, and unrelated param is present', function(done) {
+      getRoute('/test', fail, 2, done);
+    });
+
+    it('should return two errors when query is missing', function(done) {
+      getRoute('/', fail, 2, done);
+    });
+
+    it('should return a success when query validates and unrelated query is present', function(done) {
+      getRoute('/42?testparam=42', pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated query is present', function(done) {
+      getRoute('/test?testparam=blah', fail, 1, done);
+    });
+  });
+
+  describe('POST tests', function() {
+    it('should return two errors when query is missing, and unrelated param is present', function(done) {
+      postRoute('/test', null, fail, 2, done);
+    });
+
+    it('should return two errors when query is missing', function(done) {
+      postRoute('/', null, fail, 2, done);
+    });
+
+    it('should return a success when query validates and unrelated query is present', function(done) {
+      postRoute('/42?testparam=42', null, pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated query is present', function(done) {
+      postRoute('/test?testparam=blah', null, fail, 1, done);
+    });
+
+    // POST only
+
+    it('should return a success when query validates and unrelated param/body is present', function(done) {
+      postRoute('/test?testparam=42', { testparam: 'posttest' }, pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated param/body is present', function(done) {
+      postRoute('/test?testparam=blah', { testparam: '42' }, fail, 1, done);
+    });
+
+    it('should return two errors when query is missing and unrelated body is present', function(done) {
+      postRoute('/', { testparam: '42' }, fail, 2, done);
+    });
+  });
+
+});

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -2,6 +2,7 @@
 var express = require('express');
 var expressValidator = require('../../index');
 var bodyParser = require('body-parser');
+var Promise = require('bluebird');
 
 var port = process.env.PORT || 8888;
 var app = express();
@@ -14,6 +15,14 @@ module.exports = function(validation) {
     customValidators: {
       isArray: function(value) {
         return Array.isArray(value);
+      },
+      isAsyncTest: function(testparam) {
+        return new Promise(function(resolve, reject) {
+          setTimeout(function() {
+            if (testparam === '42') { return resolve(); }
+            reject();
+          }, 200);
+        });
       }
     },
     customSanitizers: {


### PR DESCRIPTION
Adds the functionality to be able to return a promise from a custom validator.

Requires that `req.asyncValidationErrors()` is used which will return a promise, rather than `req.validationErrors()` otherwise async validators may not have completed. I added a console warning if you use an async validator and then use `validationErrors`, as it could be a common mistake...

`asyncValidationErrors` will resolve if there are no errors and will reject with any (a)synchronous validation errors!