### PR TITLE
Fix the output of nested params in error object.

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -104,7 +104,7 @@ var expressValidator = function(options) {
     if (this.lastError) {
       this.validationErrors.pop();
       this.req._validationErrors.pop();
-      var error = this.errorFormatter(this.lastError.param, message, this.lastError.value);
+      var error = formatErrors.call(this, this.lastError.param, message, this.lastError.value);
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
       this.lastError = null;
@@ -269,8 +269,7 @@ function makeValidator(methodName, container) {
     args = args.concat(Array.prototype.slice.call(arguments));
 
     var isValid = container[methodName].apply(container, args);
-
-    var error = this.errorFormatter(this.param, this.failMsg || 'Invalid value', this.value);
+    var error = formatErrors.call(this, this.param, this.failMsg || 'Invalid value', this.value);
 
     if (isValid.then) {
       var promise = isValid.catch(function() {
@@ -340,5 +339,47 @@ function locate(req, name) {
   return undefined;
 }
 
+/**
+ * format param output if passed in as array (for nested)
+ * before calling errorFormatter
+ *
+ * @method param
+ * @param  {(string|string[])} param       parameter as a string or array
+ * @param  {string} msg
+ * @param  {string} value
+ * @return {function}
+ */
+function formatErrors(param, msg, value) {
+  var formattedParam = formatParamOutput(param);
+
+  return this.errorFormatter(formattedParam, msg, value);
+}
+
+// Convert nested params as array into string for output
+// Ex: ['users', '0', 'fields', 'email'] to 'users[0].fields.email'
+function formatParamOutput(param) {
+  if (Array.isArray(param)) {
+    param = param.reduce(function(prev, curr) {
+      var part = '';
+      if (validator.isInt(curr)) {
+        part = '[' + curr + ']';
+      } else {
+        if (prev) {
+          part = '.' + curr;
+        } else {
+          part = curr;
+        }
+      }
+
+      return prev + part;
+    });
+  }
+
+  return param;
+}
+
 module.exports = expressValidator;
 module.exports.validator = validator;
+module.exports.utils = {
+  formatParamOutput: formatParamOutput
+};

--- a/test/formatParamOutputTest.js
+++ b/test/formatParamOutputTest.js
@@ -1,0 +1,25 @@
+var chai = require('chai');
+var expect = chai.expect;
+var formatParamOutput = require('../index').utils.formatParamOutput;
+
+describe('#formatParamOutput()', function() {
+  it('should correct return formatted string if all elements in array are strings', function() {
+    expect(formatParamOutput(['hey', 'yo', 'hello'])).to.equal('hey.yo.hello');
+  });
+
+  it('should return a string with integers in brackets', function() {
+    expect(formatParamOutput(['hey', 'yo', '0', 'hello'])).to.equal('hey.yo[0].hello');
+    expect(formatParamOutput(['hey', 'yo', 0, 'hello'])).to.equal('hey.yo[0].hello');
+    expect(formatParamOutput(['hey', 'yo', 0, 0, 'hello'])).to.equal('hey.yo[0][0].hello');
+    expect(formatParamOutput(['hey', 'yo', 2342342, 'hello'])).to.equal('hey.yo[2342342].hello');
+    expect(formatParamOutput(['hey', 'yo', '2342342', 'hello'])).to.equal('hey.yo[2342342].hello');
+    expect(formatParamOutput(['hey', 'yo', '234ALPHA2342', 'hello'])).to.not.equal('hey.yo[234ALPHA2342].hello');
+    expect(formatParamOutput(['hey', 'yo', 'hello', 0])).to.equal('hey.yo.hello[0]');
+    expect(formatParamOutput(['hey', 'yo', 'hello', 0, 0])).to.equal('hey.yo.hello[0][0]');
+    expect(formatParamOutput(['hey', 'yo', 0, 'hello', 0, 0])).to.equal('hey.yo[0].hello[0][0]');
+  });
+
+  it('should return the original param if not an array', function() {
+    expect(formatParamOutput('yo')).to.equal('yo');
+  });
+});

--- a/test/optionalSchemaTest.js
+++ b/test/optionalSchemaTest.js
@@ -48,7 +48,7 @@ before(function() {
 });
 
 // TODO: Don't know if all of these are necessary, but we do need to test body and header
-describe('#optional()', function() {
+describe('#optionalSchema()', function() {
   it('should return a success when there is an empty route', function(done) {
     testRoute('/', pass, done);
   });

--- a/test/sanitizerResultTest.js
+++ b/test/sanitizerResultTest.js
@@ -56,7 +56,7 @@ before(function() {
   app = require('./helpers/app')(validation);
 });
 
-describe('#sanitizers', function() {
+describe('#sanitizers (check results)', function() {
   describe('GET tests', function() {
     it('should return property and sanitized value when param is present', function(done) {
       getRoute('/abcdef', pass, done);


### PR DESCRIPTION
This is a fix for https://github.com/ctavan/express-validator/issues/165.

I wrapped `errorFormatter()` in a function called `formatParamOutput` that formats the param for output. Also exported this function so that I could easily test it. In the future we could possibly add other functions to the utils object for testing.

Would appreciate a code review by @chrissinclair or @Jakeii. Just leave a comment if you've finished reviewing or have any feedback.