### PR TITLE
Optional() options, sanitizeHeaders(), and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4.0"
+  - "4.1"
 install:
   - npm install
 script:

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Schema validation will be used if you pass an object to any of the validator met
 ```javascript
 req.checkBody({
  'email': {
-  notEmpty: true,
+    notEmpty: true,
     isEmail: {
       errorMessage: 'Invalid Email'
     }
@@ -227,7 +227,7 @@ req.checkBody({
   'password': {
     notEmpty: true,
       isLength: {
-      options: [2, 10] // pass options to the valdatior with the options property as an array
+      options: [2, 10] // pass options to the validator with the options property as an array
     },
     errorMessage: 'Invalid Password' // Error message for the parameter
   },
@@ -304,7 +304,7 @@ errors:
 
 ## Optional input
 
-You can use the `optional()` method to check an input only when the input exists.
+You can use the `optional()` method to skip validation. By default, it only skips validation if the key does not exist on the request object. If you want to skip validation based on the property being falsy (null, undefined, etc), you can pass in `{ checkFalsy: true }`.
 
 ```javascript
 req.checkBody('email').optional().isEmail();

--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ Same as [req.check()](#reqcheck), but only looks in `req.query`.
 #### req.checkParams();
 Same as [req.check()](#reqcheck), but only looks in `req.params`.
 
+#### req.checkHeaders();
+Only checks `req.headers`. This method is not covered by the general `req.check()`.
+
 ## Asynchronous Validation
 
 If you need to perform asynchronous validation, for example checking a database if a username has been taken already, your custom validator can return a promise.
@@ -344,6 +347,9 @@ Same as [req.sanitize()](#reqsanitize), but only looks in `req.query`.
 
 #### req.sanitizeParams();
 Same as [req.sanitize()](#reqsanitize), but only looks in `req.params`.
+
+#### req.sanitizeHeaders();
+Only sanitizes `req.headers`. This method is not covered by the general `req.sanitize()`.
 
 ### Regex routes
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ req.sanitize('address').toSanitizeSomehow();
 
 Starts the validation of the specifed parameter, will look for the parameter in `req` in the order `params`, `query`, `body`, then validate, you can use 'dot-notation' or an array to access nested values.
 
+If a validator takes in params, you would call it like `req.assert('reqParam').contains('thisString');`.
+
 Validators are appended and can be chained. See [chriso/validator.js](https://github.com/chriso/validator.js) for available validators, or [add your own](#customvalidators).
 
 #### req.assert();
@@ -326,6 +328,8 @@ console.log(req.body.username); // 'a user'
 ```
 
 Sanitizes the specified parameter (using 'dot-notation' or array), the parameter will be updated to the sanitized result. Cannot be chained, and will return the result. See [chriso/validator.js](https://github.com/chriso/validator.js) for available sanitizers, or [add your own](#customsanitizers).
+
+If a sanitizer takes in params, you would call it like `req.sanitize('reqParam').whitelist(['a', 'b', 'c']);`.
 
 If the parameter is present in multiple places with the same name e.g. `req.params.comment` & `req.query.comment`, they will all be sanitized.
 

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -181,6 +181,14 @@ var expressValidator = function(options) {
       };
     });
 
+    req.sanitizeHeaders = function(param) {
+      if (param === 'referrer') {
+        param = 'referer';
+      }
+
+      return new Sanitizer(param, req, ['headers']);
+    };
+
     req.sanitize = function(param) {
       return new Sanitizer(param, req, locations);
     };

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -92,9 +92,24 @@ var expressValidator = function(options) {
     return this.isLength.apply(this, arguments);
   };
 
-  ValidatorChain.prototype.optional = function() {
-    if (this.value === undefined) {
-      this.skipValidating = true;
+  ValidatorChain.prototype.optional = function(opts) {
+    opts = opts || {};
+    // By default, optional checks if the key exists, but the user can pass in
+    // checkFalsy: true to skip validation if the property is falsy
+    var defaults = {
+      checkFalsy: false
+    };
+
+    var options = _.assign(defaults, opts);
+
+    if (options.checkFalsy) {
+      if (!this.value) {
+        this.skipValidating = true;
+      }
+    } else {
+      if (this.value === undefined) {
+        this.skipValidating = true;
+      }
     }
 
     return this;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "bluebird": "^2.9.x",
     "lodash": "3.10.x",
-    "validator": "4.0.x"
+    "validator": "4.2.x"
   },
   "devDependencies": {
     "body-parser": "1.12.3",

--- a/test/optionalSchemaTest.js
+++ b/test/optionalSchemaTest.js
@@ -15,6 +15,17 @@ function validation(req, res) {
     }
   });
 
+  req.assert({
+    'optional_falsy_param': {
+      optional: {
+        options: [{ checkFalsy: true }]
+      },
+      isInt: {
+        errorMessage: errorMessage
+      }
+    }
+  });
+
   var errors = req.validationErrors();
   if (errors) {
     return res.send(errors);
@@ -75,5 +86,13 @@ describe('#optionalSchema()', function() {
 
   it('should return a success when param is provided and validated', function(done) {
     testRoute('/path?optional_param=123', pass, done);
+  });
+
+  it('should return a success when the optional falsy param is present, but false', function(done) {
+    testRoute('/path?optional_falsy_param=', pass, done);
+  });
+
+  it('should return an error when the optional falsy param is present, but does not pass', function(done) {
+    testRoute('/path?optional_falsy_param=hello', fail, done);
   });
 });

--- a/test/optionalTest.js
+++ b/test/optionalTest.js
@@ -7,6 +7,7 @@ var errorMessage = 'Parameter is not an integer';
 
 function validation(req, res) {
   req.assert('optional_param', errorMessage).optional().isInt();
+  req.assert('optional_falsy_param', errorMessage).optional({ checkFalsy: true }).isInt();
 
   var errors = req.validationErrors();
   if (errors) {
@@ -68,5 +69,13 @@ describe('#optional()', function() {
 
   it('should return a success when param is provided and validated', function(done) {
     testRoute('/path?optional_param=123', pass, done);
+  });
+
+  it('should return a success when the optional falsy param is present, but false', function(done) {
+    testRoute('/path?optional_falsy_param=', pass, done);
+  });
+
+  it('should return an error when the optional falsy param is present, but does not pass', function(done) {
+    testRoute('/path?optional_falsy_param=hello', fail, done);
   });
 });

--- a/test/sanitizeHeadersTest.js
+++ b/test/sanitizeHeadersTest.js
@@ -1,0 +1,45 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+function validation(req, res) {
+  req.sanitizeHeaders('x-custom-header').trim();
+  res.send(req.headers);
+}
+
+function pass(body) {
+  expect(body).to.have.property('x-custom-header', 'space');
+}
+function fail(body) {
+  expect(body).to.have.property('x-custom-header').and.to.not.equal('space');
+}
+
+function getRoute(path, data, test, done) {
+  request(app)
+    .get(path)
+    .set('x-custom-header', data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#sanitizeHeaders', function() {
+  describe('GET tests', function() {
+    it('should return property and sanitized value when headers param is present', function(done) {
+      getRoute('/', 'space   ', pass, done);
+    });
+
+    it('should not return property when headers param is missing', function(done) {
+      getRoute('/', null, fail, done);
+    });
+  });
+});


### PR DESCRIPTION
- Added options arguments to `optional()` to allow for checking for falsy values. (fix #120)
- Added docs for sanitizer arguments (fix #182)
- Added `sanitizeHeaders()` with tests and docs. (fix #177)
- Update validator to 4.2.x
- Added Node v4.0 and v4.1 to Travis.

@ctavan ... Thoughts? I attempted to add that feature to `optional()` while still being backwards-compatible.