### PR TITLE
Options in schema validation don't have to be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ Schema validation will be used if you pass an object to any of the validator met
 ```javascript
 req.checkBody({
  'email': {
-    notEmpty: true,
+    optional: {
+      options: { checkFalsy: true } // or: [{ checkFalsy: true }]
+    },
     isEmail: {
       errorMessage: 'Invalid Email'
     }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -265,9 +265,18 @@ function validateSchema(schema, req, loc, options) {
     var paramErrorMessage = schema[param].errorMessage;
     delete schema[param].errorMessage;
 
+    var opts;
+
     for (var methodName in schema[param]) {
       validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-      validator[methodName].call(validator, schema[param][methodName].options);
+
+      opts = schema[param][methodName].options;
+
+      if(opts && !Array.isArray(opts)) {
+        opts = [opts];
+      }
+
+      validator[methodName].apply(validator, opts);
     }
   }
 }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -267,7 +267,7 @@ function validateSchema(schema, req, loc, options) {
 
     for (var methodName in schema[param]) {
       validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-      validator[methodName].apply(validator, schema[param][methodName].options);
+      validator[methodName].call(validator, schema[param][methodName].options);
     }
   }
 }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -272,7 +272,7 @@ function validateSchema(schema, req, loc, options) {
 
       opts = schema[param][methodName].options;
 
-      if(opts && !Array.isArray(opts)) {
+      if (opts && !Array.isArray(opts)) {
         opts = [opts];
       }
 

--- a/test/optionalSchemaTest.js
+++ b/test/optionalSchemaTest.js
@@ -26,6 +26,17 @@ function validation(req, res) {
     }
   });
 
+  req.assert({
+    'optional_falsy_param_array': {
+      optional: {
+        options: { checkFalsy: true }
+      },
+      isInt: {
+        errorMessage: errorMessage
+      }
+    }
+  });
+
   var errors = req.validationErrors();
   if (errors) {
     return res.send(errors);
@@ -86,6 +97,14 @@ describe('#optionalSchema()', function() {
 
   it('should return a success when param is provided and validated', function(done) {
     testRoute('/path?optional_param=123', pass, done);
+  });
+
+  it('should return a success when the optional falsy param is present, but false, defined via options array', function(done) {
+    testRoute('/path?optional_falsy_param_array=', pass, done);
+  });
+
+  it('should return an error when the optional falsy param is present, but does not pass, defined via options array', function(done) {
+    testRoute('/path?optional_falsy_param_array=hello', fail, done);
   });
 
   it('should return a success when the optional falsy param is present, but false', function(done) {


### PR DESCRIPTION
To facilitate:

    optional: {
        options: { checkFalsy: true }
    },

as an alias of

    optional: {
        options: [{ checkFalsy: true }]
    },