### PR TITLE
Upgrade dependency (validator.js) from 4.2.x -> 4.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,15 +229,16 @@ req.checkBody({
   },
   'password': {
     notEmpty: true,
-      isLength: {
-      options: [2, 10] // pass options to the validator with the options property as an array
+    match: {
+      options: ['example', 'i'] // pass options to the validator with the options property as an array
+      // options: ['/example/i'] // match also accepts the full expression in the first parameter
     },
     errorMessage: 'Invalid Password' // Error message for the parameter
   },
   'name.first': { //
     optional: true, // won't validate if field is empty
     isLength: {
-      options: [2, 10],
+      options: [{ min: 2, max: 10 }],
       errorMessage: 'Must be between 2 and 10 chars long' // Error message for the validator, takes precedent over parameter message
     },
     errorMessage: 'Invalid First Name'

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -85,7 +85,7 @@ var expressValidator = function(options) {
   });
 
   ValidatorChain.prototype.notEmpty = function() {
-    return this.isLength(1);
+    return this.isLength({ min: 1 });
   };
 
   ValidatorChain.prototype.len = function() {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "bluebird": "^2.9.x",
     "lodash": "3.10.x",
-    "validator": "4.2.x"
+    "validator": "4.5.x"
   },
   "devDependencies": {
     "body-parser": "1.12.3",

--- a/test/withMessageTest.js
+++ b/test/withMessageTest.js
@@ -12,7 +12,7 @@ function validation(req, res) {
     .notEmpty() // with default message
     .isInt().withMessage(mustBeIntegerMessage)
     .isInt() // with default message
-    .isLength(2, 2).withMessage(mustBeTwoDigitsMessage);
+    .isLength({ min: 2, max: 2 }).withMessage(mustBeTwoDigitsMessage);
   var errors = req.validationErrors();
   if (errors) {
     return res.send(errors);
@@ -84,7 +84,7 @@ describe('#withMessage()', function() {
       validator(req, {}, function() {});
       req.check('testParam', 'Default Error Message')
         .isInt() // should produce 'Default Error Message'
-        .isLength(2).withMessage('Custom Error Message');
+        .isLength({ min: 2 }).withMessage('Custom Error Message');
 
       expect(req.validationErrors()).to.deep.equal([
         { param: 'testParam', msg: 'Default Error Message', value: 'abc' }


### PR DESCRIPTION
Minor change in API, backwards compatibility maintained:

- isLenght({ min: 2, max: 10 })
- isByteLenght({ min: 2, max: 10 })
- isLenght({ min: 4 })
- isByteLenght({ max: 8 })

closes #196

NOTE: This PR includes changes to README which illustrate an api which changed, so a new version should be released after merging. Backwards compatibility was maintained so a minor version bump should suffice.