### PR TITLE
Upgraded bluebird

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -174,6 +174,8 @@ var expressValidator = function(options) {
     req.asyncValidationErrors = function(mapped) {
       return new Promise(function(resolve, reject) {
         var promises = req._asyncValidationErrors;
+        // Migrated using the recommended fix from
+        // http://bluebirdjs.com/docs/api/reflect.html
         Promise.all(promises.map(function(promise) {
           return promise.reflect();
         })).then(function(results) {

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -174,7 +174,9 @@ var expressValidator = function(options) {
     req.asyncValidationErrors = function(mapped) {
       return new Promise(function(resolve, reject) {
         var promises = req._asyncValidationErrors;
-        Promise.settle(promises).then(function(results) {
+        Promise.all(promises.map(function(promise) {
+          return promise.reflect();
+        })).then(function(results) {
 
           results.forEach(function(result) {
             if (result.isRejected()) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "bluebird": "^2.9.x",
+    "bluebird": "3.3.x",
     "lodash": "4.6.x",
     "validator": "4.9.x"
   },


### PR DESCRIPTION
If I understood the functionality of reflect correctly, this should be the fix needed for the upgrade. It's a bit unfortunate that they took down the documentation for `.settle()` so that I cannot really look the semantics up.