### PR TITLE
Convert promises to Bluebird promises in order to use reflect(). 

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -177,7 +177,10 @@ var expressValidator = function(options) {
         // Migrated using the recommended fix from
         // http://bluebirdjs.com/docs/api/reflect.html
         Promise.all(promises.map(function(promise) {
-          return promise.reflect();
+          // Must convert to Bluebird promise in case they are using native
+          // Node promises since reflect() is not a native promise method
+          // http://bluebirdjs.com/docs/api/reflect.html#comment-2369616577
+          return Promise.resolve(promise).reflect();
         })).then(function(results) {
 
           results.forEach(function(result) {

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -2,10 +2,15 @@
 var express = require('express');
 var expressValidator = require('../../index');
 var bodyParser = require('body-parser');
-var Promise = require('bluebird');
 
 var port = process.env.PORT || 8888;
 var app = express();
+
+// If no native implementation of Promise exists (less than Node v4),
+// use Bluebird promises so we can test for both depending on the Node version
+if (typeof Promise === 'undefined') {
+  Promise = require('bluebird');
+}
 
 module.exports = function(validation) {
 


### PR DESCRIPTION
Based on http://bluebirdjs.com/docs/api/reflect.html#comment-2369616577, should fix #220.