### PR TITLE
Fixing warning from node-validator

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -335,7 +335,7 @@ function makeValidator(methodName, container) {
     args.push(this.value);
     args = args.concat(Array.prototype.slice.call(arguments));
 
-    var isValid = container[methodName].apply(container, args);
+    var isValid = !args[0] ? false : container[methodName].apply(container, args);
     var error = formatErrors.call(this, this.param, this.failMsg || 'Invalid value', this.value);
 
     if (isValid.then) {


### PR DESCRIPTION
If you try to check an `undefined` field (the goal of the library in a nutshell), you get this warning from the `node-validator` library :

> validator deprecated you tried to validate a undefined but this library (validator.js) validates strings only. Please update your code as this will be an error soon. node_modules/express-validator/lib/express_validator.js:338:41

Code sample :

```javascript
req.assert('firstName', "missing_firstName").notEmpty(); // The error comes from here if this param is undefined
req.assert('lastName', "missing_lastName").notEmpty();
req.assert('username', "missing_username").notEmpty();
req.assert('password', "missing_password").notEmpty();

req.assert('username', "invalid_username").isEmail();
req.assert('password', "password_too_short").len(6);
```

This commit should fix the problem.