### PR TITLE
Upgrade node-validator to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 An [express.js]( https://github.com/visionmedia/express ) middleware for
 [node-validator]( https://github.com/chriso/validator.js ).
 
+*Note: As of node-validator's v5, it does not automatically coerce values to strings, but it still requires strings as input. So now express-validator will automatically coerce your input to strings before to passes to node-validator. Ideally, `notEmpty()` should still function as normal.*
+
 ## Installation
 
 ```
@@ -119,18 +121,18 @@ Define your custom validators:
 ```javascript
 app.use(expressValidator({
  customValidators: {
-    isArray: function(value) {
-        return Array.isArray(value);
+    saysHello: function(value) {
+        return value === "Hello";
     },
     gte: function(param, num) {
-        return param >= num;
+        return Number(param) >= Number(num);
     }
  }
 }));
 ```
 Use them with their validator name:
 ```javascript
-req.checkBody('users', 'Users must be an array').isArray();
+req.checkBody('users', 'Users must be an array').saysHello();
 req.checkQuery('time', 'Time must be an integer great than or equal to 5').isInt().gte(5)
 ```
 ####`customSanitizers`

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -85,6 +85,13 @@ var expressValidator = function(options) {
   });
 
   ValidatorChain.prototype.notEmpty = function() {
+    if (this.value == null) {
+      var error = formatErrors.call(this, this.param, this.failMsg || 'Invalid value', this.value);
+      this.validationErrors.push(error);
+      this.req._validationErrors.push(error);
+      this.lastError = { param: this.param, value: this.value, isAsync: false };
+      return this;
+    }
     return this.isLength({
       min: 1
     });
@@ -332,7 +339,7 @@ function makeValidator(methodName, container) {
     }
 
     var args = [];
-    args.push(this.value);
+    args.push(this.value += '');
     args = args.concat(Array.prototype.slice.call(arguments));
 
     var isValid = container[methodName].apply(container, args);
@@ -377,7 +384,7 @@ function makeSanitizer(methodName, container) {
     var result;
     this.values.forEach(function(value, i) {
       if (value != null) {
-        var args = [value];
+        var args = [value += ''];
         args = args.concat(Array.prototype.slice.call(_arguments));
         result = container[methodName].apply(container, args);
 
@@ -433,7 +440,7 @@ function formatParamOutput(param) {
   if (Array.isArray(param)) {
     param = param.reduce(function(prev, curr) {
       var part = '';
-      if (validator.isInt(curr)) {
+      if (validator.isInt(curr.toString())) {
         part = '[' + curr + ']';
       } else {
         if (prev) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "bluebird": "3.3.x",
     "lodash": "4.6.x",
-    "validator": "4.9.x"
+    "validator": "5.2.x"
   },
   "devDependencies": {
     "body-parser": "1.12.3",

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -12,8 +12,10 @@ function validation(req, res) {
       notEmpty: true,
       isInt: true
     },
-    'arrayParam': {
-      isArray: true
+    'numParam': {
+      gte: {
+        options: [5]
+      }
     }
   });
 
@@ -95,23 +97,19 @@ describe('#checkBodySchema()', function() {
     });
 
     it('should return a success when params validate on the body', function(done) {
-      postRoute('/?testparam=blah', { testparam: '42', arrayParam: [1, 2, 3] }, pass, null, done);
+      postRoute('/?testparam=blah', { testparam: '42', numParam: 10 }, pass, null, done);
     });
 
     it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: 123 }, fail, 2, done);
+      postRoute('/?testparam=42', { testparam: 'posttest', numParam: 1 }, fail, 2, done);
     });
 
     it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: {} }, fail, 2, done);
-    });
-
-    it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/', { testparam: 'test', arrayParam: '[]' }, fail, 2, done);
+      postRoute('/', { testparam: 'test', numParam: '[]' }, fail, 2, done);
     });
 
     it('should return a success when params validate on the body', function(done) {
-      postRoute('/', { testparam: '42', arrayParam: [] }, pass, null, done);
+      postRoute('/', { testparam: '42', numParam: 10 }, pass, null, done);
     });
   });
 });

--- a/test/checkBodyTest.js
+++ b/test/checkBodyTest.js
@@ -14,7 +14,7 @@ var errorMessage = 'Parameter is not an integer';
 
 function validation(req, res) {
   req.checkBody('testparam', errorMessage).notEmpty().isInt();
-  req.checkBody('arrayParam').isArray();
+  req.checkBody('numParam').gte(5);
 
   var errors = req.validationErrors();
   if (errors) {
@@ -93,23 +93,19 @@ describe('#checkBody()', function() {
     });
 
     it('should return a success when params validate on the body', function(done) {
-      postRoute('/?testparam=blah', { testparam: '42', arrayParam: [1, 2, 3] }, pass, null, done);
+      postRoute('/?testparam=blah', { testparam: '42', numParam: 10 }, pass, null, done);
     });
 
     it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: 123 }, fail, 2, done);
+      postRoute('/?testparam=42', { testparam: 'posttest', numParam: 1 }, fail, 2, done);
     });
 
     it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: {} }, fail, 2, done);
-    });
-
-    it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/', { testparam: 'test', arrayParam: '[]' }, fail, 2, done);
+      postRoute('/', { testparam: 'test', numParam: '[]' }, fail, 2, done);
     });
 
     it('should return a success when params validate on the body', function(done) {
-      postRoute('/', { testparam: '42', arrayParam: [] }, pass, null, done);
+      postRoute('/', { testparam: '42', numParam: 10 }, pass, null, done);
     });
   });
 

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -18,8 +18,8 @@ module.exports = function(validation) {
   app.use(bodyParser.json());
   app.use(expressValidator({
     customValidators: {
-      isArray: function(value) {
-        return Array.isArray(value);
+      gte: function(param, value) {
+        return Number(param) >= Number(value);
       },
       isAsyncTest: function(testparam) {
         return new Promise(function(resolve, reject) {

--- a/test/withMessageAsyncTest.js
+++ b/test/withMessageAsyncTest.js
@@ -69,7 +69,7 @@ describe('#withMessage()', function() {
 						expect(err).to.deep.equal([{
 							msg: 'Custom Message',
 							param: 'testParam',
-							value: 100
+							value: '100'
 						}]);
 					});
 			});


### PR DESCRIPTION
Upgrade node-validator to v5 and automatically coerce values to strings on our end since node-validator doesn't do it anymore, but requires strings as input.

Would love a thorough review by a few of these people if possible: @ctavan, @fvargas, @Jakeii, @chrissinclair, @AuspeXeu, @JaniszM 

Did I miss anything? Should this be a major or minor version bump?