### PR TITLE
Update node-validator to v5 and restore automatic string coercion.

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -2,6 +2,47 @@ var validator = require('validator');
 var _ = require('lodash');
 var Promise = require('bluebird');
 
+// When validator upgraded to v5, they removed automatic string coercion
+// The next few methods (up to validator.init()) restores that functionality
+// so that express-validator can continue to function normally
+validator.extend = function(name, fn) {
+  validator[name] = function() {
+    var args = Array.prototype.slice.call(arguments);
+    args[0] = validator.toString(args[0]);
+    return fn.apply(validator, args);
+  };
+};
+
+validator.init = function() {
+  for (var name in validator) {
+  if (typeof validator[name] !== 'function' || name === 'toString' ||
+    name === 'toDate' || name === 'extend' || name === 'init' ||
+    name === 'isServerSide') {
+      continue;
+  }
+  validator.extend(name, validator[name]);
+  }
+};
+
+validator.toString = function(input) {
+  if (typeof input === 'object' && input !== null && input.toString) {
+    input = input.toString();
+  } else if (input === null || typeof input === 'undefined' || (isNaN(input) && !input.length)) {
+    input = '';
+  }
+  return '' + input;
+};
+
+validator.toDate = function(date) {
+  if (Object.prototype.toString.call(date) === '[object Date]') {
+    return date;
+  }
+  date = Date.parse(date);
+  return !isNaN(date) ? new Date(date) : null;
+};
+
+validator.init();
+
 // validators and sanitizers not prefixed with is/to
 var additionalValidators = ['contains', 'equals', 'matches'];
 var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'stripLow', 'whitelist', 'blacklist', 'normalizeEmail'];

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "bluebird": "3.3.x",
     "lodash": "4.6.x",
-    "validator": "4.9.x"
+    "validator": "5.2.x"
   },
   "devDependencies": {
     "body-parser": "1.12.3",


### PR DESCRIPTION
Added lines from @Jakeii's suggestion in https://github.com/ctavan/express-validator/pull/229, so that all tests pass with an upgrade to node-validator v5.