### PR TITLE
Allowed to use wildcards in schema validation

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -481,7 +481,7 @@ function makeValidator(methodName, container) {
     } else if (!isValid) {
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
-      this.lastError = {param: this.param, value: this.value, isAsync: false};
+      this.lastError = { param: this.param, value: this.value, isAsync: false };
     } else {
       this.lastError = null;
     }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -11,16 +11,27 @@ var wildcard = require('wildcard');
  */
 _.wget = function(object, path, defaultValue) {
   if (_.isString(path) && path.indexOf('*') > -1) {
+    var fixPath = path.split('*')[0].slice(0, -1);
+    var wildPath = path.replace(fixPath, '').slice(1);
+    var parts = wildPath.split('.');
     var values = {};
 
-    traverse(object).forEach(function(value) {
+    object = _.get(object, fixPath, {});
+
+    traverse(object).forEach(function(node) {
       var currentPath = this.path.join('.');
-      if (wildcard(path, currentPath)) values[currentPath] = value;
+      var extendedPath = parts.map(function(p, k) { return p === '*' ? this.path[k] || p : p; }.bind(this)).join('.');
+    
+      if (this.isLeaf && wildcard(wildPath, extendedPath) && !wildcard(wildPath, currentPath)) {
+        values[[fixPath, extendedPath].join('.')] = null;
+      }
+
+      if (wildcard(wildPath, currentPath)) {
+        values[[fixPath, currentPath].join('.')] = node;
+      }
     });
 
-    if (_.isEmpty(values)) {
-      values[defaultValue] = null;
-    }
+    if (_.isEmpty(values)) values[defaultValue] = null;
 
     return values;
   } else {

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -1,6 +1,46 @@
 var validator = require('validator');
 var _ = require('lodash');
 var Promise = require('bluebird');
+var traverse = require('traverse');
+var wildcard = require('wildcard');
+
+/**
+ * @param object {Object}
+ * @param path {String}
+ * @param defaultValue {*}
+ */
+_.wget = function(object, path, defaultValue) {
+  if (_.isString(path) && path.indexOf('*') > -1) {
+    var values = {};
+
+    traverse(object).forEach(function(value) {
+      var currentPath = this.path.join('.');
+      if (wildcard(path, currentPath)) values[currentPath] = value;
+    });
+
+    if (_.isEmpty(values)) {
+      values[defaultValue] = null;
+    }
+
+    return values;
+  } else {
+    return _.get(object, path, defaultValue);
+  }
+};
+
+/**
+ * @param object {Object}
+ * @param path {String}
+ */
+_.whas = function(object, path) {
+  if (_.isString(path) && path.indexOf('*') > -1) {
+    return traverse(object).paths().some(function(currentPath) {
+      return wildcard(path, currentPath.join('.'));
+    });
+  } else {
+    return _.has(object, path);
+  }
+};
 
 // When validator upgraded to v5, they removed automatic string coercion
 // The next few methods (up to validator.init()) restores that functionality
@@ -15,12 +55,12 @@ validator.extend = function(name, fn) {
 
 validator.init = function() {
   for (var name in validator) {
-  if (typeof validator[name] !== 'function' || name === 'toString' ||
-    name === 'toDate' || name === 'extend' || name === 'init' ||
-    name === 'isServerSide') {
+    if (typeof validator[name] !== 'function' || name === 'toString' ||
+      name === 'toDate' || name === 'extend' || name === 'init' ||
+      name === 'isServerSide') {
       continue;
-  }
-  validator.extend(name, validator[name]);
+    }
+    validator.extend(name, validator[name]);
   }
 };
 
@@ -160,24 +200,24 @@ var expressValidator = function(options) {
 
   ValidatorChain.prototype.withMessage = function(message) {
     if (this.lastError) {
-        if (this.lastError.isAsync) {
-            this.req._asyncValidationErrors.pop().catch(function() {
-              // Suppress errors from original promise - they should go to the new one.
-              // Otherwise bluebird throws an 'unhandled rejection' error
-            });
-            var error = formatErrors.call(this.lastError.context, this.lastError.param, message, this.lastError.value);
-            var promise = this.lastError.promise.catch(function() {
-                return Promise.reject(error);
-            });
-            this.req._asyncValidationErrors.push(promise);
-        } else {
-            this.validationErrors.pop();
-            this.req._validationErrors.pop();
-            var errorMessage = formatErrors.call(this, this.lastError.param, message, this.lastError.value);
-            this.validationErrors.push(errorMessage);
-            this.req._validationErrors.push(errorMessage);
-            this.lastError = null;
-        }
+      if (this.lastError.isAsync) {
+        this.req._asyncValidationErrors.pop().catch(function() {
+          // Suppress errors from original promise - they should go to the new one.
+          // Otherwise bluebird throws an 'unhandled rejection' error
+        });
+        var error = formatErrors.call(this.lastError.context, this.lastError.param, message, this.lastError.value);
+        var promise = this.lastError.promise.catch(function() {
+          return Promise.reject(error);
+        });
+        this.req._asyncValidationErrors.push(promise);
+      } else {
+        this.validationErrors.pop();
+        this.req._validationErrors.pop();
+        var errorMessage = formatErrors.call(this, this.lastError.param, message, this.lastError.value);
+        this.validationErrors.push(errorMessage);
+        this.req._validationErrors.push(errorMessage);
+        this.lastError = null;
+      }
     }
     return this;
   };
@@ -326,7 +366,6 @@ function validateSchema(schema, req, loc, options) {
     currentLoc = loc;
 
   for (var param in schema) {
-
     // check if schema has defined location
     if (schema[param].hasOwnProperty('in')) {
       if (locations.indexOf(schema[param].in) !== -1) {
@@ -338,7 +377,11 @@ function validateSchema(schema, req, loc, options) {
     }
 
     currentLoc = currentLoc === 'any' ? locate(req, param) : currentLoc;
-    var validator = new ValidatorChain(param, null, req, currentLoc, options);
+
+    var validator = _.isString(param) && param.indexOf('*') > -1 ? _.keys(_.wget(req[currentLoc], param, param)).map(function(p) {
+      return new ValidatorChain(p, null, req, currentLoc, options);
+    }) : new ValidatorChain(param, null, req, currentLoc, options);
+
     var paramErrorMessage = schema[param].errorMessage;
     delete schema[param].errorMessage;
 
@@ -351,8 +394,17 @@ function validateSchema(schema, req, loc, options) {
         currentLoc = loc;
         continue;
       }
-      validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-      validator[methodName].apply(validator, schema[param][methodName].options);
+
+      if (_.isArray(validator)) {
+        validator = validator.map(function(v) {
+          v.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
+          v[methodName].apply(v, schema[param][methodName].options);
+          return v;
+        });
+      } else {
+        validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
+        validator[methodName].apply(validator, schema[param][methodName].options);
+      }
     }
   }
 }
@@ -394,7 +446,7 @@ function makeValidator(methodName, container) {
     } else if (!isValid) {
       this.validationErrors.push(error);
       this.req._validationErrors.push(error);
-      this.lastError = { param: this.param, value: this.value, isAsync: false };
+      this.lastError = {param: this.param, value: this.value, isAsync: false};
     } else {
       this.lastError = null;
     }
@@ -441,11 +493,12 @@ function makeSanitizer(methodName, container) {
  */
 
 function locate(req, name) {
-  if (_.get(req.params, name)) {
+
+  if (_.wget(req.params, name)) {
     return 'params';
-  } else if (_.has(req.query, name)) {
+  } else if (_.whas(req.query, name)) {
     return 'query';
-  } else if (_.has(req.body, name)) {
+  } else if (_.whas(req.body, name)) {
     return 'body';
   }
 

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -21,7 +21,7 @@ _.wget = function(object, path, defaultValue) {
     traverse(object).forEach(function(node) {
       var currentPath = this.path.join('.');
       var extendedPath = parts.map(function(p, k) { return p === '*' ? this.path[k] || p : p; }.bind(this)).join('.');
-    
+
       if (this.isLeaf && wildcard(wildPath, extendedPath) && !wildcard(wildPath, currentPath)) {
         values[[fixPath, extendedPath].join('.')] = null;
       }
@@ -31,7 +31,9 @@ _.wget = function(object, path, defaultValue) {
       }
     });
 
-    if (_.isEmpty(values)) values[defaultValue] = null;
+    if (_.isEmpty(values)) {
+      values[defaultValue] = null;
+    }
 
     return values;
   } else {
@@ -344,6 +346,36 @@ var expressValidator = function(options) {
 };
 
 /**
+ * @param {string|Array} param
+ * @param {Request}      req
+ * @param {string}       currentLoc
+ * @param {*}            options
+ *
+ * @returns {ValidatorChain|Array<ValidatorChain>}
+ */
+function produceValidators(param, req, currentLoc, options) {
+  if (_.isString(param) && param.indexOf('*') > -1) {
+    return _.keys(_.wget(req[currentLoc], param, param)).map(function(p) {
+      return new ValidatorChain(p, null, req, currentLoc, options);
+    });
+  } else {
+    return new ValidatorChain(param, null, req, currentLoc, options);
+  }
+}
+
+/**
+ * @param {Object}         schema
+ * @param {string}         param
+ * @param {string}         methodName
+ * @param {string}         paramErrorMessage
+ * @param {ValidatorChain} validator
+ */
+function applyValidator(schema, param, methodName, paramErrorMessage, validator) {
+  validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
+  validator[methodName].apply(validator, schema[param][methodName].options);
+}
+
+/**
  * validate an object using a schema, using following format:
  *
  * {
@@ -389,10 +421,7 @@ function validateSchema(schema, req, loc, options) {
 
     currentLoc = currentLoc === 'any' ? locate(req, param) : currentLoc;
 
-    var validator = _.isString(param) && param.indexOf('*') > -1 ? _.keys(_.wget(req[currentLoc], param, param)).map(function(p) {
-      return new ValidatorChain(p, null, req, currentLoc, options);
-    }) : new ValidatorChain(param, null, req, currentLoc, options);
-
+    var validator = produceValidators(param, req, currentLoc, options);
     var paramErrorMessage = schema[param].errorMessage;
     delete schema[param].errorMessage;
 
@@ -407,14 +436,9 @@ function validateSchema(schema, req, loc, options) {
       }
 
       if (_.isArray(validator)) {
-        validator = validator.map(function(v) {
-          v.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-          v[methodName].apply(v, schema[param][methodName].options);
-          return v;
-        });
+        validator.forEach(applyValidator.bind(null, schema, param, methodName, paramErrorMessage));
       } else {
-        validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-        validator[methodName].apply(validator, schema[param][methodName].options);
+        applyValidator(schema, param, methodName, paramErrorMessage, validator);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "dependencies": {
     "bluebird": "3.3.x",
     "lodash": "4.6.x",
-    "validator": "5.2.x"
+    "traverse": "^0.6.6",
+    "validator": "5.2.x",
+    "wildcard": "^1.1.2"
   },
   "devDependencies": {
     "body-parser": "1.12.3",

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -26,7 +26,7 @@ function validation(req, res) {
     return res.send(errors);
   }
 
-  res.send({testparam: req.body.testparam});
+  res.send({ testparam: req.body.testparam });
 }
 
 function fail(body, length) {
@@ -95,14 +95,14 @@ describe('#checkBodySchema()', function() {
     });
 
     it('should return four errors when one param is present, but does not validate', function(done) {
-      postRoute('/42?testparam=42', {testparam: 'posttest'}, fail, 4, done);
+      postRoute('/42?testparam=42', { testparam: 'posttest' }, fail, 4, done);
     });
 
     it('should return a success when params validate on the body', function(done) {
       postRoute('/?testparam=blah', {
         testparam: '42',
         arrayParam: [1, 2, 3],
-        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+        wildcard: { a: { d: { param: 1 } }, b: { e: { param: 1 } }, c: { f: { param: 1 } } }
       }, pass, null, done);
     });
 
@@ -110,7 +110,7 @@ describe('#checkBodySchema()', function() {
       postRoute('/?testparam=42', {
         testparam: 'posttest',
         arrayParam: 123,
-        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+        wildcard: { a: { d: { param: 1 } }, b: { e: { param: 1 } }, c: { f: { param: 1 } } }
       }, fail, 2, done);
     });
 
@@ -118,7 +118,7 @@ describe('#checkBodySchema()', function() {
       postRoute('/?testparam=42', {
         testparam: 'posttest',
         arrayParam: [1, 2, 3],
-        wildcard: {a: {d: {param: 'string'}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+        wildcard: { a: { d: { param: 'string' } }, b: { e: { param: 1 } }, c: { f: { param: 1 } } }
       }, fail, 2, done);
     });
 
@@ -126,7 +126,7 @@ describe('#checkBodySchema()', function() {
       postRoute('/', {
         testparam: 'test',
         arrayParam: '[]',
-        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+        wildcard: { a: { d: { param: 1 } }, b: { e: { param: 1 } }, c: { f: { param: 1 } } }
       }, fail, 2, done);
     });
 
@@ -134,7 +134,7 @@ describe('#checkBodySchema()', function() {
       postRoute('/', {
         testparam: '42',
         arrayParam: [],
-        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+        wildcard: { a: { d: { param: 1 } }, b: { e: { param: 1 } }, c: { f: { param: 1 } } }
       }, pass, null, done);
     });
 
@@ -142,7 +142,7 @@ describe('#checkBodySchema()', function() {
       postRoute('/', {
         testparam: '42',
         arrayParam: [],
-        wildcard: {a: {d: {notparam: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+        wildcard: { a: { d: { notparam: 1 } }, b: { e: { param: 1 } }, c: { f: { param: 1 } } }
       }, fail, 2, done);
     });
 
@@ -150,7 +150,7 @@ describe('#checkBodySchema()', function() {
       postRoute('/', {
         testparam: '42',
         arrayParam: [],
-        wildcard: {a: {d: {notparam: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}, g: {h: true}}
+        wildcard: { a: { d: { notparam: 1 } }, b: { e: { param: 1 } }, c: { f: { param: 1 } }, g: { h: true } }
       }, fail, 4, done);
     });
   });

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -137,5 +137,21 @@ describe('#checkBodySchema()', function() {
         wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
       }, pass, null, done);
     });
+
+    it('should return two error when one params are not present', function(done) {
+      postRoute('/', {
+        testparam: '42',
+        arrayParam: [],
+        wildcard: {a: {d: {notparam: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+      }, fail, 2, done);
+    });
+
+    it('should return two error when two params are not present', function(done) {
+      postRoute('/', {
+        testparam: '42',
+        arrayParam: [],
+        wildcard: {a: {d: {notparam: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}, g: {h: true}}
+      }, fail, 4, done);
+    });
   });
 });

--- a/test/checkBodySchemaTest.js
+++ b/test/checkBodySchemaTest.js
@@ -14,6 +14,10 @@ function validation(req, res) {
     },
     'arrayParam': {
       isArray: true
+    },
+    'wildcard.*.*.param': {
+      notEmpty: true,
+      isInt: true
     }
   });
 
@@ -22,7 +26,7 @@ function validation(req, res) {
     return res.send(errors);
   }
 
-  res.send({ testparam: req.body.testparam });
+  res.send({testparam: req.body.testparam});
 }
 
 function fail(body, length) {
@@ -62,56 +66,76 @@ before(function() {
 
 describe('#checkBodySchema()', function() {
   describe('GET tests', function() {
-    it('should return three errors when param is missing', function(done) {
-      getRoute('/', fail, 3, done);
+    it('should return five errors when param is missing', function(done) {
+      getRoute('/', fail, 5, done);
     });
 
-    it('should return three errors when param is present, but not in the body', function(done) {
-      getRoute('/42', fail, 3, done);
+    it('should return five errors when param is present, but not in the body', function(done) {
+      getRoute('/42', fail, 5, done);
     });
   });
 
   describe('POST tests', function() {
-    it('should return three errors when param is missing', function(done) {
-      postRoute('/', null, fail, 3, done);
+    it('should return five errors when param is missing', function(done) {
+      postRoute('/', null, fail, 5, done);
     });
 
-    it('should return three errors when param is present, but not in the body', function(done) {
-      postRoute('/42', null, fail, 3, done);
+    it('should return five errors when param is present, but not in the body', function(done) {
+      postRoute('/42', null, fail, 5, done);
     });
 
     // POST only
 
-    it('should return three errors when params are not present', function(done) {
-      postRoute('/test?testparam=gettest', null, fail, 3, done);
+    it('should return five errors when params are not present', function(done) {
+      postRoute('/test?testparam=gettest', null, fail, 5, done);
     });
 
-    it('should return three errors when param is present, but not in body', function(done) {
-      postRoute('/42?testparam=42', null, fail, 3, done);
+    it('should return five errors when param is present, but not in body', function(done) {
+      postRoute('/42?testparam=42', null, fail, 5, done);
     });
 
-    it('should return two errors when one param is present, but does not validate', function(done) {
-      postRoute('/42?testparam=42', { testparam: 'posttest' }, fail, 2, done);
-    });
-
-    it('should return a success when params validate on the body', function(done) {
-      postRoute('/?testparam=blah', { testparam: '42', arrayParam: [1, 2, 3] }, pass, null, done);
-    });
-
-    it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: 123 }, fail, 2, done);
-    });
-
-    it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/?testparam=42', { testparam: 'posttest', arrayParam: {} }, fail, 2, done);
-    });
-
-    it('should return two errors when two params are present, but do not validate', function(done) {
-      postRoute('/', { testparam: 'test', arrayParam: '[]' }, fail, 2, done);
+    it('should return four errors when one param is present, but does not validate', function(done) {
+      postRoute('/42?testparam=42', {testparam: 'posttest'}, fail, 4, done);
     });
 
     it('should return a success when params validate on the body', function(done) {
-      postRoute('/', { testparam: '42', arrayParam: [] }, pass, null, done);
+      postRoute('/?testparam=blah', {
+        testparam: '42',
+        arrayParam: [1, 2, 3],
+        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+      }, pass, null, done);
+    });
+
+    it('should return two errors when two params are present, but do not validate', function(done) {
+      postRoute('/?testparam=42', {
+        testparam: 'posttest',
+        arrayParam: 123,
+        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+      }, fail, 2, done);
+    });
+
+    it('should return two errors when two params are present, but do not validate', function(done) {
+      postRoute('/?testparam=42', {
+        testparam: 'posttest',
+        arrayParam: [1, 2, 3],
+        wildcard: {a: {d: {param: 'string'}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+      }, fail, 2, done);
+    });
+
+    it('should return two errors when two params are present, but do not validate', function(done) {
+      postRoute('/', {
+        testparam: 'test',
+        arrayParam: '[]',
+        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+      }, fail, 2, done);
+    });
+
+    it('should return a success when params validate on the body', function(done) {
+      postRoute('/', {
+        testparam: '42',
+        arrayParam: [],
+        wildcard: {a: {d: {param: 1}}, b: {e: {param: 1}}, c: {f: {param: 1}}}
+      }, pass, null, done);
     });
   });
 });


### PR DESCRIPTION
Hy!

I need this feature in my projects, so I thought I will try to solve it. My problem was how to validate the "array-like" nested objects in a complex input, and maybe it's relevant to #125 issue. 

**Definition:**

``` js
req.checkBody({
 'users.*.email': {
    notEmpty: {
      errorMessage: 'Missing Email'
    },
    isEmail: {
      errorMessage: 'Invalid Email'
    }
  }
});
```

**Request:**

``` json
{
  "users": [
    {"email": "example@mail.com"},
    {"email": "example.mail.com"},
    {"notemail": "example2@mail.com"}
  ]
}
```

_or_

``` json
{
  "users": {
    "0": {"email": "example@mail.com"},
    "1": {"email": "example.mail.com"},
    "2": {"notemail": "example2@mail.com"}
  }
}
```

**Response:**

``` json
{
  "errors": [
    {
      "param": "users.1.email",
      "msg": "Invalid Email",
      "value": "example.mail.com"
    },
    {
      "param": "users.2.email",
      "msg": "Missing Email"
    },
    {
      "param": "users.2.email",
      "msg": "Invalid Email"
    }
  ]
}
```
