### PR TITLE
avoid deletion of param error message when using schema validation

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -340,7 +340,6 @@ function validateSchema(schema, req, loc, options) {
     currentLoc = currentLoc === 'any' ? locate(req, param) : currentLoc;
     var validator = new ValidatorChain(param, null, req, currentLoc, options);
     var paramErrorMessage = schema[param].errorMessage;
-    delete schema[param].errorMessage;
 
     for (var methodName in schema[param]) {
       if (methodName === 'in') {
@@ -351,6 +350,15 @@ function validateSchema(schema, req, loc, options) {
         currentLoc = loc;
         continue;
       }
+
+      if (methodName === 'errorMessage') {
+        /**
+         * Also do not validate if methodName
+         * represent parameter error mesage
+         */
+        continue;
+      }
+
       validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
       validator[methodName].apply(validator, schema[param][methodName].options);
     }


### PR DESCRIPTION
Please check open issue https://github.com/ctavan/express-validator/issues/242 for example and details.
Changes from PR will not `delete` param error message from schema, it will skip validation if `methodName` is equal to `errorMessage`. On this way same predefined schema in application can be reused safely.