### PR TITLE
Fix a bug for body schema checking

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -352,7 +352,7 @@ function validateSchema(schema, req, loc, options) {
         continue;
       }
       validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-      validator[methodName].apply(validator, schema[param][methodName].options);
+      validator[methodName].call(validator, schema[param][methodName].options);
     }
   }
 }


### PR DESCRIPTION
When my schema has options, the options won't be passed to my custom validators. By looking through the code and found out the wrong usage of apply and call.

Please merge it to master. thanks