### PR TITLE
Fixing the apply call that invokes validator methods that are...

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -360,7 +360,7 @@ function validateSchema(schema, req, loc, options) {
       }
 
       validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-      validator[methodName].apply(validator, schema[param][methodName].options);
+      validator[methodName].apply(validator, [schema[param][methodName].options]);
     }
   }
 }


### PR DESCRIPTION
…declared in schema validators. The second parameter of apply is an array of args that get passed into the invoked function. Given that the array brackets were missing from the apply call, when a validator function's options param was an array, the validator function would just take the first item of the options array, rather than the whole options array. Adding brackets to the second param of the apply call allows both objects and arrays to be passed properly to validator methods.