### PR TITLE
Upgraded validator to 5.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "bluebird": "3.4.x",
     "lodash": "4.13.x",
-    "validator": "5.4.x"
+    "validator": "5.5.x"
   },
   "devDependencies": {
     "body-parser": "1.12.3",


### PR DESCRIPTION
Hey, remember when stackoverflow went down the other day? It's because of a bug in trimming strings, which is fixed in validator 5.5. Read more: http://stackstatus.net/post/147710624694/outage-postmortem-july-20-2016