### PR TITLE
String formatting for error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,23 @@ mappedErrors:
 ```
 *Note: Using mappedErrors will only provide the last error per param in the chain of validation errors.*
 
+### String formatting for error messages
+
+Error messages can be customized to include both the value provided by the user, as well as the value of any parameters passed to the validation function, using a standard string replacement format:
+
+`%0` is replaced with user input  
+`%1` is replaced with the first parameter to the validator  
+`%2` is replaced with the second parameter to the validator  
+etc...
+
+Example:
+```javascript
+req.assert('number', '%0 is not an integer').isInt();
+req.assert('number', '%0 is not divisible by %1').isDivisibleBy(5);
+```
+
+*Note:* string replacement does **not** work with the `.withMessage()` syntax. If you'd like to have per-validator error messages with string formatting, please use the [Validation by Schema](#validation-by-schema) method instead.
+
 ### Per-validation messages
 
 You can provide an error message for a single validation with `.withMessage()`. This can be chained with the rest of your validation, and if you don't use it for one of the validations then it will fall back to the default.

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -385,7 +385,13 @@ function makeValidator(methodName, container) {
     args = args.concat(Array.prototype.slice.call(arguments));
 
     var isValid = container[methodName].apply(container, args);
-    var error = formatErrors.call(this, this.param, this.failMsg || 'Invalid value', this.value);
+
+    // Perform string replacement in the error message
+    var msg = this.failMsg;
+    if (typeof msg === 'string') {
+      args.forEach(function(arg, i) { msg = msg.replace('%' + i, arg); });
+    }
+    var error = formatErrors.call(this, this.param, msg || 'Invalid value', this.value);
 
     if (isValid.then) {
       var promise = isValid.catch(function() {

--- a/test/formatErrorTest.js
+++ b/test/formatErrorTest.js
@@ -1,0 +1,50 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var emailErrorMessage = '%0 is not a valid email';
+var dateErrorMessage = '%0 is not before %1';
+var beforeDate = '2016-01-01';
+
+function validation(req, res) {
+  req.assert('email', emailErrorMessage).isEmail();
+  req.assert('date', dateErrorMessage).isBefore(beforeDate);
+
+  var errors = req.validationErrors(true);
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({
+    email: req.params.email || req.query.email || req.body.email,
+    date: req.params.date || req.query.date || req.body.date
+  });
+}
+
+function fail(body) {
+  expect(body).to.have.deep.property('email.msg', emailErrorMessage.replace('%0', body.email.value));
+  expect(body).to.have.deep.property('date.msg', dateErrorMessage.replace('%0', body.date.value).replace('%1', beforeDate));
+}
+
+function testRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('Error message string formatting', function() {
+  it('should return a mapped error object with a properly formatted error message', function(done) {
+    testRoute('/path', { email: 'incorrect', date: '2016-12-31' }, fail, done);
+  });
+});


### PR DESCRIPTION
In prior versions of express-validator, you could include tokens like
%0, %1, etc in error message, and validator.js would replace them with
the value of the input or parameters passed to the validators.

This commit restores that behavior.

%0 is the value of the parameter being tested
%1... are the values of the parameters passed to the validator function
itself.