### PR TITLE
Nesting check that requires all children to fail

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -182,6 +182,26 @@ var expressValidator = function(options) {
     return this;
   };
 
+  ValidatorChain.prototype.all = function(childChains) {
+    var childrenFailed = _.every(childChains, function(chain) {
+      return chain.validationErrors.length > 0;
+    });
+    if (childrenFailed) {
+      var parentError = formatErrors.call(this, this.param, this.failMsg, this.value);
+      var failed = _.map(childChains, function(chain) {
+        return chain.param;
+      });
+      var cleanedErrors = this.req._validationErrors.filter(
+        function(error) {
+          return !_.includes(failed, error.param);
+        }
+      );
+      cleanedErrors.push(parentError);
+      this.req._validationErrors = cleanedErrors;
+    }
+    return this;
+  };
+
   _.forEach(options.customValidators, function(method, customValidatorName) {
     ValidatorChain.prototype[customValidatorName] = makeValidator(customValidatorName, options.customValidators);
   });

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -198,6 +198,7 @@ var expressValidator = function(options) {
       );
       cleanedErrors.push(parentError);
       this.req._validationErrors = cleanedErrors;
+      this.validationErrors.push(parentError);
     }
     return this;
   };

--- a/test/allTest.js
+++ b/test/allTest.js
@@ -1,0 +1,65 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var parentError = 'Enter your name';
+
+function validation(req, res) {
+  req.check('name', parentError).all([
+    req.check('firstName', 'Enter your first name').notEmpty(),
+    req.check('lastName', 'Enter your last name').notEmpty()
+  ]);
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.sendStatus(200);
+}
+
+function fail(param) {
+  return function(res) {
+    expect(res.body).to.have.length(1);
+    expect(res.body[0]).to.have.property('param', param);
+  };
+}
+
+function pass(res) {
+  expect(res.status).to.eql(200);
+}
+
+function postRoute(data, test, done) {
+  request(app)
+    .post('/')
+    .send(data)
+    .end(function(err, res) {
+      test(res);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#all', function() {
+  it('should return no errors if children pass', function(done) {
+    postRoute({ firstName: 'John', lastName: 'Smith' }, pass, done);
+  });
+
+  it('should return the child error if some children fail', function(done) {
+    postRoute({ firstName: 'John' }, fail('lastName'), done);
+  });
+
+  it('should return the child error if some children fail', function(done) {
+    postRoute({ lastName: 'Smith' }, fail('firstName'), done);
+  });
+
+  it('should return the parent error if all children fail', function(done) {
+    postRoute({}, fail('name'), done);
+  });
+});


### PR DESCRIPTION
This pull request proposes a way of overriding a set of child checks with a parent check if all the children fail.

The proposed interface to this is a `ValidatorChain` named `all`, which accepts a list of `ValidatorChains` and checks that they all failed. If they all did it removes them from the requests `_validationErrors` list and adds it's own error in their place.

Example:

```
req.check('name', 'Please enter your name').all([
    req.check('firstName', 'Enter your first name').notEmpty(),
    req.check('lastName', 'Enter your last name').notEmpty()
]);
```

---

**Background**

This comes from the approach to errors that I've previously used on GDS services where we want to provide error messages that are as human readable as possible. For example:
- Providing no input at all gives: _Please enter your date of birth_

![image](https://cloud.githubusercontent.com/assets/1446145/18004366/57ff9354-6b8b-11e6-995a-01193af48eb6.png)
- Only filling in some of the fields gives errors for each field

![image](https://cloud.githubusercontent.com/assets/1446145/18004402/a7a906ba-6b8b-11e6-9897-9e6dbf1ae313.png)

This is a simple example but they can get quite complex. The aim is always to allow the message to the user to be as simple and understandable as possible.
