### PR TITLE
Fixes optional params breaking req.check

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -335,9 +335,10 @@ function validateSchema(schema, req, loc, options) {
         // skip params where defined location is not supported
         continue;
       }
+    } else {
+      currentLoc = loc === 'any' ? locate(req, param) : currentLoc;
     }
 
-    currentLoc = currentLoc === 'any' ? locate(req, param) : currentLoc;
     var validator = new ValidatorChain(param, null, req, currentLoc, options);
     var paramErrorMessage = schema[param].errorMessage;
 

--- a/test/checkOptionalSchemaTest.js
+++ b/test/checkOptionalSchemaTest.js
@@ -41,7 +41,7 @@ var validOptional = {
 var invalidAll = {
 	optional_body: invalidOptionalBodyValue,
 	required_body: invalidRequiredBodyValue
-}
+};
 
 var invalidRequired = {
 	optional_body: optionalBodyValue,
@@ -88,7 +88,7 @@ function passAll(body) {
 function passRequired(body) {
 
 	expect(body).to.have.property('required_body', requiredBodyValue);
-	expect(body.optional_body).to.be.undefined;
+	expect(body).to.not.have.property('optional_body');
 }
 
 function failAll(body) {
@@ -136,38 +136,38 @@ before(function() {
   app = require('./helpers/app')(validation);
 });
 
-describe('Check with optional validators in schema', function () {
-	it('should pass validation with all parameters sent', function (done) {
+describe('Check with optional validators in schema', function() {
+	it('should pass validation with all parameters sent', function(done) {
 		postRoute('/', validAll, passAll, done);
 	});
 
-	it('should pass validation with only required parameter sent', function (done) {
+	it('should pass validation with only required parameter sent', function(done) {
 		postRoute('/', validRequired, passRequired, done);
 	});
 
-	it('should fail validation with all invalid parameters sent', function (done) {
+	it('should fail validation with all invalid parameters sent', function(done) {
 		postRoute('/', invalidAll, failAll, done);
 	});
 
-	it('should fail validation with invalid required parameter sent', function (done) {
+	it('should fail validation with invalid required parameter sent', function(done) {
 		postRoute('/', invalidRequired, failRequired, done);
 	});
 
-	it('should fail validation with only invalid parameter', function (done) {
+	it('should fail validation with only invalid parameter', function(done) {
 		postRoute('/', invalidRequiredOnly, failRequired, done);
 	});
 
-	it('should fail validation with invalid optional parameter sent', function (done) {
+	it('should fail validation with invalid optional parameter sent', function(done) {
 		postRoute('/', invalidOptional, failOptional, done);
 	});
 
-	it('should fail validation with only valid optional parameter sent', function (done) {
+	it('should fail validation with only valid optional parameter sent', function(done) {
 		postRoute('/', validOptional, failUndefinedRequired, done);
 	});
 
-	it('should fail validation with only invalid optional parameter sent', function (done) {
+	it('should fail validation with only invalid optional parameter sent', function(done) {
 		postRoute('/', invalidOptionalOnly, failUndefinedRequiredInvalidOptional, done);
 	});
-})
+});
 
 

--- a/test/checkOptionalSchemaTest.js
+++ b/test/checkOptionalSchemaTest.js
@@ -1,0 +1,173 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+
+var optionalBodyErr = 'Invalid optional_body';
+var requiredBodyErr = 'Invalid required_body';
+
+var optionalBodyValue = 11;
+var requiredBodyValue = 22;
+
+var invalidOptionalBodyValue = 'aa';
+var invalidRequiredBodyValue = 'bb';
+
+var schema = {
+	optional_body: {
+		optional: true,
+		isInt: true,
+		errorMessage: optionalBodyErr
+	},
+	required_body: {
+		isInt: true,
+		errorMessage: requiredBodyErr
+	}
+};
+
+var validAll = {
+	optional_body: optionalBodyValue,
+	required_body: requiredBodyValue
+};
+
+var validRequired = {
+	required_body: requiredBodyValue
+};
+
+var validOptional = {
+	optional_body: optionalBodyValue
+};
+
+var invalidAll = {
+	optional_body: invalidOptionalBodyValue,
+	required_body: invalidRequiredBodyValue
+}
+
+var invalidRequired = {
+	optional_body: optionalBodyValue,
+	required_body: invalidRequiredBodyValue
+};
+
+var invalidRequiredOnly = {
+	required_body: invalidRequiredBodyValue
+};
+
+var invalidOptional = {
+	optional_body: invalidOptionalBodyValue,
+	required_body: requiredBodyValue
+};
+
+var invalidOptionalOnly = {
+	optional_body: invalidOptionalBodyValue
+};
+
+function validationSendResponse(req, res) {
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+
+  res.send({
+    optional_body: req.body.optional_body,
+    required_body: req.body.required_body
+  });
+}
+
+function validation(req, res) {
+
+  req.check(schema);
+  validationSendResponse(req, res);
+}
+
+function passAll(body) {
+
+	expect(body).to.have.property('optional_body', optionalBodyValue);
+	expect(body).to.have.property('required_body', requiredBodyValue);
+}
+
+function passRequired(body) {
+
+	expect(body).to.have.property('required_body', requiredBodyValue);
+	expect(body.optional_body).to.be.undefined;
+}
+
+function failAll(body) {
+
+	expect(body).to.deep.include({ msg: optionalBodyErr, param: 'optional_body', value: invalidOptionalBodyValue });
+	expect(body).to.deep.include({ msg: requiredBodyErr, param: 'required_body', value: invalidRequiredBodyValue });
+}
+
+function failRequired(body) {
+
+	expect(body).to.deep.include({ msg: requiredBodyErr, param: 'required_body', value: invalidRequiredBodyValue });
+}
+
+function failOptional(body) {
+
+	expect(body).to.deep.include({ msg: optionalBodyErr, param: 'optional_body', value: invalidOptionalBodyValue });
+}
+
+function failUndefinedRequired(body) {
+
+	expect(body).to.deep.include({ msg: requiredBodyErr, param: 'required_body' });
+}
+
+function failUndefinedRequiredInvalidOptional(body) {
+
+	expect(body).to.deep.include({ msg: requiredBodyErr, param: 'required_body' });
+	expect(body).to.deep.include({ msg: optionalBodyErr, param: 'optional_body', value: invalidOptionalBodyValue });
+}
+
+
+function postRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('Check with optional validators in schema', function () {
+	it('should pass validation with all parameters sent', function (done) {
+		postRoute('/', validAll, passAll, done);
+	});
+
+	it('should pass validation with only required parameter sent', function (done) {
+		postRoute('/', validRequired, passRequired, done);
+	});
+
+	it('should fail validation with all invalid parameters sent', function (done) {
+		postRoute('/', invalidAll, failAll, done);
+	});
+
+	it('should fail validation with invalid required parameter sent', function (done) {
+		postRoute('/', invalidRequired, failRequired, done);
+	});
+
+	it('should fail validation with only invalid parameter', function (done) {
+		postRoute('/', invalidRequiredOnly, failRequired, done);
+	});
+
+	it('should fail validation with invalid optional parameter sent', function (done) {
+		postRoute('/', invalidOptional, failOptional, done);
+	});
+
+	it('should fail validation with only valid optional parameter sent', function (done) {
+		postRoute('/', validOptional, failUndefinedRequired, done);
+	});
+
+	it('should fail validation with only invalid optional parameter sent', function (done) {
+		postRoute('/', invalidOptionalOnly, failUndefinedRequiredInvalidOptional, done);
+	});
+})
+
+


### PR DESCRIPTION
Fixes issue with: https://github.com/ctavan/express-validator/issues/259

BUG: If a schema with `optional: true` is passed to `req.check` and the optional parameter is omitted from the request, then the `locate` function will return `undefined` for that parameter and all subsequent validations will not run.