### PR TITLE
add sanitize option in validate schema

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -361,7 +361,21 @@ function validateSchema(schema, req, loc, options) {
       }
 
       validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-      validator[methodName].apply(validator, schema[param][methodName].options);
+
+      if(validator[methodName]){
+        validator[methodName].apply(validator, schema[param][methodName].options);
+      }
+      else if(methodName==='sanitize'){
+
+        for(var index in schema[param][methodName]){
+          var currentSanitize = schema[param][methodName][index];
+          var funcName = "validator.req.sanitize('"+param+"')."+currentSanitize+"()";
+          eval(funcName);
+        }
+
+        
+      }
+
     }
   }
 }


### PR DESCRIPTION
Added sanitize option in validate schema that will sanitize the param.

var Schema ={
         'duration':{
            'optional' : true,
            'sanitize' : ['escape']
        }
};
