### PR TITLE
Fixed error in README (async validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ app.use(expressValidator({
       return new Promise(function(resolve, reject) {
         User.findOne({ username: username })
         .then(function(user) {
-          if (user) {
+          if (!user) {
             resolve(user);
           }
           else {


### PR DESCRIPTION
Fixed error in the Asyncronous validation example. The promise was resolving in the case of user existing which should do the opposite