### PR TITLE
Introducing friendlier API for retrieving validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,10 @@ req.assert('email', 'Invalid email')
     .notEmpty().withMessage('Email is required')
     .isEmail();
 
-req.getValidationErrors(function(errors){
-  // do something with errors
-});
+req.getValidationErrors()
+   .then(function(errors){
+     // do something with errors
+   });
 
 ```
 errors:

--- a/README.md
+++ b/README.md
@@ -48,15 +48,18 @@ app.post('/:urlparam', function(req, res) {
   // OR find the relevent param in all areas
   req.sanitize('postparam').toBoolean();
 
-  var errors = req.validationErrors();
-  if (errors) {
-    res.send('There have been validation errors: ' + util.inspect(errors), 400);
-    return;
-  }
-  res.json({
-    urlparam: req.params.urlparam,
-    getparam: req.params.getparam,
-    postparam: req.params.postparam
+  // Alternatively use `var errors = yield req.getValidationErrors();`
+  // when using generators e.g. with co-express
+  req.getValidationErrors().then(function(errors) {
+    if (errors) {
+      res.send('There have been validation errors: ' + util.inspect(errors), 400);
+      return;
+    }
+    res.json({
+      urlparam: req.params.urlparam,
+      getparam: req.params.getparam,
+      postparam: req.params.postparam
+    });
   });
 });
 
@@ -87,7 +90,7 @@ There have been validation errors: [
 ####`errorFormatter`
 _function(param,msg,value)_
 
-The `errorFormatter` option can be used to specify a function that can be used to format the objects that populate the error array that is returned in `req.validationErrors()`. It should return an `Object` that has `param`, `msg`, and `value` keys defined.
+The `errorFormatter` option can be used to specify a function that can be used to format the objects that populate the error array that is returned in `req.getValidationErrors()`. It should return an `Object` that has `param`, `msg`, and `value` keys defined.
 
 ```javascript
 // In this example, the formParam value is going to get morphed into form body format useful for printing.
@@ -189,49 +192,6 @@ Same as [req.check()](#reqcheck), but only looks in `req.params`.
 #### req.checkHeaders();
 Only checks `req.headers`. This method is not covered by the general `req.check()`.
 
-## Asynchronous Validation
-
-If you need to perform asynchronous validation, for example checking a database if a username has been taken already, your custom validator can return a promise.
-
-You **MUST** use `asyncValidationErrors` which returns a promise to check for errors, otherwise the validator promises won't be resolved.
-
- *`asyncValidationErrors` will also return any regular synchronous validation errors.*
-
- ```javascript
-app.use(expressValidator({
-  customValidators: {
-    isUsernameAvailable: function(username) {
-      return new Promise(function(resolve, reject) {
-        User.findOne({ username: username })
-        .then(function(user) {
-          if (!user) {
-            resolve();
-          }
-          else {
-            reject(user);
-          }
-        })
-        .catch(function(error){
-          if (error) {
-            reject(error);
-          }
-        });
-      });
-    }
-  }
-}));
-
-req.check('username', 'Username Taken').isUsernameAvailable();
-
-req.asyncValidationErrors()
-.then(function() {
-// create user
-})
-.catch(function(errors) {
-  res.send(errors);
-});
-
-```
 ## Validation by Schema
 
 Alternatively you can define all your validations at once using a simple schema.
@@ -316,18 +276,18 @@ Currently supported location are `'body', 'params', 'query'`. If you provide a l
 
 ## Validation errors
 
-You have two choices on how to get the validation errors:
+You have two choices for getting validation errors:
 
 ```javascript
 req.assert('email', 'required').notEmpty();
 req.assert('email', 'valid email required').isEmail();
 req.assert('password', '6 to 20 characters required').len(6, 20);
 
-var errors = req.validationErrors(); // Or req.asyncValidationErrors();
-var mappedErrors = req.validationErrors(true); // Or req.asyncValidationErrors(true);
+req.getValidationErrors(); // Basic errors
+req.getValidationErrors(true); // Mapped Errors
 ```
 
-errors:
+Basic Errors:
 
 ```javascript
 [
@@ -337,7 +297,7 @@ errors:
 ]
 ```
 
-mappedErrors:
+Mapped Errors:
 
 ```javascript
 {
@@ -353,7 +313,7 @@ mappedErrors:
   }
 }
 ```
-*Note: Using mappedErrors will only provide the last error per param in the chain of validation errors.*
+*Note: Using mapped errors will only provide the last error per param in the chain of validation errors.*
 
 ### String formatting for error messages
 
@@ -380,7 +340,11 @@ You can provide an error message for a single validation with `.withMessage()`. 
 req.assert('email', 'Invalid email')
     .notEmpty().withMessage('Email is required')
     .isEmail();
-var errors = req.validationErrors();
+
+req.getValidationErrors(function(errors){
+  // do something with errors
+});
+
 ```
 errors:
 
@@ -450,6 +414,12 @@ You can validate the extracted matches like this:
 ```javascript
 req.assert(0, 'Not a three-digit integer.').len(3, 3).isInt();
 ```
+
+## Deprecated methods
+
+Express Validator previously recommended using `req.validationErrors()` and
+`req.asyncValidationErrors()` which have now been deprecated in favour of
+`req.getValidationErrors()`.
 
 ## Changelog
 

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -238,6 +238,32 @@ var expressValidator = function(options) {
       });
     };
 
+    req.getValidationErrors = function(mapped) {
+      return new Promise(function(resolve) {
+        var promises = req._asyncValidationErrors;
+        // Migrated using the recommended fix from
+        // http://bluebirdjs.com/docs/api/reflect.html
+        Promise.all(promises.map(function(promise) {
+          // Must convert to Bluebird promise in case they are using native
+          // Node promises since reflect() is not a native promise method
+          // http://bluebirdjs.com/docs/api/reflect.html#comment-2369616577
+          return Promise.resolve(promise).reflect();
+        })).then(function(results) {
+          results.forEach(function(result) {
+            if (result.isRejected()) {
+              req._validationErrors.push(result.reason());
+            }
+          });
+
+          if (req._validationErrors.length > 0) {
+            return resolve(req.validationErrors(mapped, true));
+          }
+
+          resolve(null);
+        });
+      });
+    };
+
     locations.forEach(function(location) {
       req['sanitize' + _.capitalize(location)] = function(param) {
         return new Sanitizer(param, req, [location]);

--- a/test/getValidationErrorsTest.js
+++ b/test/getValidationErrorsTest.js
@@ -1,0 +1,115 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not 42';
+
+// There are three ways to pass parameters to express:
+// - as part of the URL
+// - as GET parameter in the querystring
+// - as POST parameter in the body
+// These test show that req.checkQuery are only interested in req.query values, all other
+// parameters will be ignored.
+
+function validation(req, res) {
+  req.checkQuery('testparam', errorMessage).notEmpty().isAsyncTest();
+
+  req.getValidationErrors().then(function(errors) {
+    if (errors) {
+      res.send(errors);
+    } else {
+      res.send({ testparam: req.query.testparam });
+    }
+  }).catch(function(err) {
+    throw err;
+  });
+}
+
+function fail(body, length) {
+  expect(body).to.have.length(length);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('testparam', '42');
+}
+
+function getRoute(path, test, length, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+function postRoute(path, data, test, length, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function(err, res) {
+      test(res.body, length);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#validateTest()', function() {
+  describe('GET tests', function() {
+    it('should return two errors when query is missing, and unrelated param is present', function(done) {
+      getRoute('/test', fail, 2, done);
+    });
+
+    it('should return two errors when query is missing', function(done) {
+      getRoute('/', fail, 2, done);
+    });
+
+    it('should return a success when query validates and unrelated query is present', function(done) {
+      getRoute('/42?testparam=42', pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated query is present', function(done) {
+      getRoute('/test?testparam=blah', fail, 1, done);
+    });
+  });
+
+  describe('POST tests', function() {
+    it('should return two errors when query is missing, and unrelated param is present', function(done) {
+      postRoute('/test', null, fail, 2, done);
+    });
+
+    it('should return two errors when query is missing', function(done) {
+      postRoute('/', null, fail, 2, done);
+    });
+
+    it('should return a success when query validates and unrelated query is present', function(done) {
+      postRoute('/42?testparam=42', null, pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated query is present', function(done) {
+      postRoute('/test?testparam=blah', null, fail, 1, done);
+    });
+
+    // POST only
+
+    it('should return a success when query validates and unrelated param/body is present', function(done) {
+      postRoute('/test?testparam=42', { testparam: 'posttest' }, pass, null, done);
+    });
+
+    it('should return one error when query does not validate as int and unrelated param/body is present', function(done) {
+      postRoute('/test?testparam=blah', { testparam: '42' }, fail, 1, done);
+    });
+
+    it('should return two errors when query is missing and unrelated body is present', function(done) {
+      postRoute('/', { testparam: '42' }, fail, 2, done);
+    });
+  });
+
+});

--- a/test/getValidationErrorsTest.js
+++ b/test/getValidationErrorsTest.js
@@ -61,7 +61,7 @@ before(function() {
   app = require('./helpers/app')(validation);
 });
 
-describe('#validateTest()', function() {
+describe('#getValidationErrorsTest()', function() {
   describe('GET tests', function() {
     it('should return two errors when query is missing, and unrelated param is present', function(done) {
       getRoute('/test', fail, 2, done);


### PR DESCRIPTION
As mentioned in issue #249 the API for retrieving validation errors is rather cumbersome. 

To solve this problem I've introduced a new `req.getValidationErrors()` method which is async by default and returns errors as part of the promise resolution. This makes it easier to write readable code, especially when coupled with generators, and keeps code consistent when switching between sync/async.

For example, using generators with the new method code is now written as such:

```javascript
var errors = yield req.getValidationErrors();

if (errors) {
  res.send('There were errors');
} else {
  res.send('All is well');
}
```