### PR TITLE
#getValidationResult() validation result object

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,6 +5,7 @@
     "sub": true,
     "curly": true,
     "eqeqeq": true,
+    "expr": true,
     "indent": 4,
     "latedef": "nofunc",
     "newcap": true,

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An [express.js]( https://github.com/visionmedia/express ) middleware for
   + [Per-validation messages](#per-validation-messages)
 - [Optional input](#optional-input)
 - [Sanitizer](#sanitizer)
+- [Regex routes](#regex-routes)
 - [Changelog](#changelog)
 - [License](#license)
 
@@ -101,8 +102,8 @@ There have been validation errors: [
   { param: 'postparam', msg: 'Invalid postparam', value: undefined} ]
 ```
 
-### Middleware Options
-####`errorFormatter`
+## Middleware Options
+#### `errorFormatter`
 _function(param,msg,value)_
 
 The `errorFormatter` option can be used to specify a function that must build the error objects used in the validation result returned by `req.getValidationResult()`.<br>
@@ -495,7 +496,7 @@ Only sanitizes `req.headers`. This method is not covered by the general `req.san
 #### req.sanitizeCookies();
 Only sanitizes `req.cookies`. This method is not covered by the general `req.sanitize()`.
 
-### Regex routes
+## Regex routes
 
 Express allows you to define regex routes like:
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ app.post('/:urlparam', function(req, res) {
   // OR find the relevent param in all areas
   req.sanitize('postparam').toBoolean();
 
-  // Alternatively use `var result = yield req.getValidationErrors();`
+  // Alternatively use `var result = yield req.getValidationResult();`
   // when using generators e.g. with co-express
-  req.getValidationErrors().then(function(result) {
+  req.getValidationResult().then(function(result) {
     if (!result.isEmpty()) {
       res.send('There have been validation errors: ' + util.inspect(errors.array()), 400);
       return;
@@ -90,7 +90,8 @@ There have been validation errors: [
 ####`errorFormatter`
 _function(param,msg,value)_
 
-The `errorFormatter` option can be used to specify a function that can be used to format the objects that populate the error array that is returned in `req.getValidationErrors()`. It should return an `Object` that has `param`, `msg`, and `value` keys defined.
+The `errorFormatter` option can be used to specify a function that must build the error objects used in the validation result returned by `req.getValidationResult()`.<br>
+It should return an `Object` that has `param`, `msg`, and `value` keys defined.
 
 ```javascript
 // In this example, the formParam value is going to get morphed into form body format useful for printing.
@@ -277,16 +278,16 @@ req.checkParams(schema);  // will check 'password' in path params but 'email' in
 
 Currently supported location are `'body', 'params', 'query'`. If you provide a location parameter that is not supported, the validation process for current parameter will be skipped.
 
-## Validation errors
+## Validation result
 
-The method `req.getValidationErrors()` returns a Promise which resolves to a result object.
+The method `req.getValidationResult()` returns a Promise which resolves to a result object.
 
 ```js
 req.assert('email', 'required').notEmpty();
 req.assert('email', 'valid email required').isEmail();
 req.assert('password', '6 to 20 characters required').len(6, 20);
 
-req.getValidationErrors().then(function(result) {
+req.getValidationResult().then(function(result) {
   // do something with the validation result
 });
 ```
@@ -385,7 +386,7 @@ req.assert('email', 'Invalid email')
     .notEmpty().withMessage('Email is required')
     .isEmail();
 
-req.getValidationErrors()
+req.getValidationResult()
    .then(function(result){
      console.log(result.array());
    });
@@ -468,7 +469,7 @@ req.assert(0, 'Not a three-digit integer.').len(3, 3).isInt();
 
 Express Validator previously recommended using `req.validationErrors()` and
 `req.asyncValidationErrors()` which have now been deprecated in favour of
-`req.getValidationErrors()`.
+`req.getValidationResult()`.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ app.post('/:urlparam', function(req, res) {
   // when using generators e.g. with co-express
   req.getValidationResult().then(function(result) {
     if (!result.isEmpty()) {
-      res.send('There have been validation errors: ' + util.inspect(errors.array()), 400);
+      res.send('There have been validation errors: ' + util.inspect(result.array()), 400);
       return;
     }
     res.json({

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ An [express.js]( https://github.com/visionmedia/express ) middleware for
 - [Validation](#validation)
 - [Validation by schema](#validation-by-schema)
 - [Validation result](#validation-result)
+  + [Result API](#result-api)
+  + [Deprecated API](#deprecated-api)
+  + [String formatting for error messages](#string-formatting-for-error-messages)
+  + [Per-validation messages](#per-validation-messages)
 - [Optional input](#optional-input)
 - [Sanitizer](#sanitizer)
 - [Changelog](#changelog)
@@ -291,6 +295,7 @@ Currently supported location are `'body', 'params', 'query'`. If you provide a l
 
 ## Validation result
 
+### Result API
 The method `req.getValidationResult()` returns a Promise which resolves to a result object.
 
 ```js
@@ -305,10 +310,10 @@ req.getValidationResult().then(function(result) {
 
 The API for the result object is the following:
 
-### `result.isEmpty()`
+#### `result.isEmpty()`
 Returns a boolean determining whether there were errors or not.
 
-### `result.useFirstErrorOnly()`
+#### `result.useFirstErrorOnly()`
 Sets the `firstErrorOnly` flag of this result object, which modifies the way
 other methods like `result.array()` and `result.mapped()` work.<br>
 
@@ -318,7 +323,7 @@ This method is chainable, so the following is OK:
 result.useFirstErrorOnly().array();
 ```
 
-### `result.array()`
+#### `result.array()`
 Returns an array of errors.<br>
 All errors for all validated parameters will be included, unless you specify that you want only the first error of each param by invoking `result.useFirstErrorOnly()`.
 
@@ -333,7 +338,7 @@ var errors = result.array();
 ]
 ```
 
-### `result.mapped()`
+#### `result.mapped()`
 Returns an object of errors, where the key is the parameter name, and the value is an error object as returned by the error formatter.
 
 Because of historical reasons, by default this method will return the last error of each parameter.<br>
@@ -357,7 +362,7 @@ var errors = result.mapped();
 }
 ```
 
-### `result.throw()`
+#### `result.throw()`
 If there are errors, throws an `Error` object which is decorated with the same API as the validation result object.<br>
 Useful for dealing with the validation errors in the `catch` block of a `try..catch` or promise.
 
@@ -369,6 +374,34 @@ try {
   console.log(e.array());
   res.send('oops, validation failed!');
 }
+```
+
+### Deprecated API
+The following methods are deprecated.<br>
+While they work, their API is unflexible and sometimes return weird results if compared to the bleeding edge `req.getValidationResult()`.
+
+Additionally, these methods may be removed in a future version.
+
+#### `req.validationErrors([mapped])`
+Returns synchronous errors in the form of an array, or an object that maps parameter to error in case `mapped` is passed as `true`.<br>
+If there are no errors, the returned value is `false`.
+
+```js
+var errors = req.validationErrors();
+if (errors) {
+  // do something with the errors
+}
+```
+
+#### `req.asyncValidationErrors([mapped])`
+Returns a promise that will either resolve if no validation errors happened, or reject with an errors array/mapping object. For reference on this, see `req.validationErrors()`.
+
+```js
+req.asyncValidationErrors().then(function() {
+  // all good here
+}, function(errors) {
+  // damn, validation errors!
+});
 ```
 
 ### String formatting for error messages
@@ -475,12 +508,6 @@ You can validate the extracted matches like this:
 ```javascript
 req.assert(0, 'Not a three-digit integer.').len(3, 3).isInt();
 ```
-
-## Deprecated methods
-
-Express Validator previously recommended using `req.validationErrors()` and
-`req.asyncValidationErrors()` which have now been deprecated in favour of
-`req.getValidationResult()`.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 An [express.js]( https://github.com/visionmedia/express ) middleware for
 [node-validator]( https://github.com/chriso/validator.js ).
 
+- [Installation](#installation)
+- [Usage](#usage)
+- [Middleware options](#middleware-options)
+- [Validation](#validation)
+- [Validation by schema](#validation-by-schema)
+- [Validation result](#validation-result)
+- [Optional input](#optional-input)
+- [Sanitizer](#sanitizer)
+- [Changelog](#changelog)
+- [License](#license)
+
 ## Installation
 
 ```

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -239,7 +239,7 @@ var expressValidator = function(options) {
       });
     };
 
-    req.getValidationErrors = function() {
+    req.getValidationResult = function() {
       return new Promise(function(resolve) {
         var promises = req._asyncValidationErrors;
         // Migrated using the recommended fix from

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -239,7 +239,7 @@ var expressValidator = function(options) {
       });
     };
 
-    req.getValidationErrors = function(mapped) {
+    req.getValidationErrors = function() {
       return new Promise(function(resolve) {
         var promises = req._asyncValidationErrors;
         // Migrated using the recommended fix from
@@ -256,11 +256,7 @@ var expressValidator = function(options) {
             }
           });
 
-          if (req._validationErrors.length > 0) {
-            return resolve(req.validationErrors(mapped, true));
-          }
-
-          resolve(null);
+          return resolve(utils.decorateAsValidationResult({}, req._validationErrors));
         });
       });
     };

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -1,6 +1,7 @@
 var validator = require('validator');
 var _ = require('lodash');
 var Promise = require('bluebird');
+var utils = require('./utils');
 
 // When validator upgraded to v5, they removed automatic string coercion
 // The next few methods (up to validator.init()) restores that functionality
@@ -524,36 +525,11 @@ function locate(req, name) {
  * @return {function}
  */
 function formatErrors(param, msg, value) {
-  var formattedParam = formatParamOutput(param);
+  var formattedParam = utils.formatParamOutput(param);
 
   return this.errorFormatter(formattedParam, msg, value);
 }
 
-// Convert nested params as array into string for output
-// Ex: ['users', '0', 'fields', 'email'] to 'users[0].fields.email'
-function formatParamOutput(param) {
-  if (Array.isArray(param)) {
-    param = param.reduce(function(prev, curr) {
-      var part = '';
-      if (validator.isInt(curr)) {
-        part = '[' + curr + ']';
-      } else {
-        if (prev) {
-          part = '.' + curr;
-        } else {
-          part = curr;
-        }
-      }
-
-      return prev + part;
-    });
-  }
-
-  return param;
-}
-
 module.exports = expressValidator;
 module.exports.validator = validator;
-module.exports.utils = {
-  formatParamOutput: formatParamOutput
-};
+module.exports.utils = utils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,3 +24,46 @@ exports.formatParamOutput = function formatParamOutput(param) {
 
   return param;
 };
+
+exports.decorateAsValidationResult = function decorateAsValidationResult(obj, errors) {
+  var onlyFirstError = false;
+
+  obj.isEmpty = function isEmpty() {
+    return !errors.length;
+  };
+
+  obj.array = function allErrors() {
+    var used = {};
+    return !onlyFirstError ? errors : errors.filter(function(error) {
+      if (used[error.param]) {
+        return false;
+      }
+
+      used[error.param] = true;
+      return true;
+    });
+  };
+
+  obj.mapped = function mappedErrors() {
+    return errors.reduce(function(mapping, error) {
+      if (!onlyFirstError || !mapping[error.param]) {
+        mapping[error.param] = error;
+      }
+
+      return mapping;
+    }, {});
+  };
+
+  obj.useFirstErrorOnly = function useFirstErrorOnly(flag) {
+    onlyFirstError = flag === undefined || flag;
+    return obj;
+  };
+
+  obj.throw = function throwError() {
+    if (errors.length) {
+      throw decorateAsValidationResult(new Error('Validation failed'), errors);
+    }
+  };
+
+  return obj;
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,26 @@
+var validator = require('validator');
+
+module.exports = exports = {};
+
+// Convert nested params as array into string for output
+// Ex: ['users', '0', 'fields', 'email'] to 'users[0].fields.email'
+exports.formatParamOutput = function formatParamOutput(param) {
+  if (Array.isArray(param)) {
+    param = param.reduce(function(prev, curr) {
+      var part = '';
+      if (validator.isInt(curr)) {
+        part = '[' + curr + ']';
+      } else {
+        if (prev) {
+          part = '.' + curr;
+        } else {
+          part = curr;
+        }
+      }
+
+      return prev + part;
+    });
+  }
+
+  return param;
+};

--- a/test/decorateAsValidationResultTest.js
+++ b/test/decorateAsValidationResultTest.js
@@ -1,0 +1,92 @@
+var chai = require('chai');
+var expect = chai.expect;
+var decorateAsValidationResult = require('../index').utils.decorateAsValidationResult;
+
+describe('#decorateAsValidationResult()', function() {
+  beforeEach(function() {
+    this.result = decorateAsValidationResult({}, [{
+        param: 'foo',
+        message: '1'
+      }, {
+        param: 'foo',
+        message: '2'
+      }, {
+        param: 'bar',
+        message: '1'
+      }]);
+  });
+
+  it('returns original object', function() {
+    var obj = {};
+    expect(decorateAsValidationResult(obj, [])).to.equal(obj);
+  });
+
+  describe('adds #isEmpty() which', function() {
+    it('should return false for when there is at least one error', function() {
+      expect(decorateAsValidationResult({}, [{}]).isEmpty()).to.be.false;
+    });
+
+    it('should return true for when there are no errors', function() {
+      expect(decorateAsValidationResult({}, []).isEmpty()).to.be.true;
+    });
+  });
+
+  describe('adds #array() which', function() {
+    it('should return all errors when firstErrorOnly is not enabled', function() {
+      expect(this.result.array()).to.have.length(3);
+    });
+
+    it('should return only first error of each param when firstErrorOnly is enabled', function() {
+      var errors = this.result.useFirstErrorOnly().array();
+      expect(errors).to.have.length(2);
+      expect(errors).to.include({ param: 'foo', message: '1' });
+      expect(errors).to.include({ param: 'bar', message: '1' });
+      expect(errors).to.not.include({ param: 'foo', message: '2' });
+    });
+  });
+
+  describe('adds #mapped() which', function() {
+    it('should return last error for each param when firstErrorOnly is disabled', function() {
+      expect(this.result.mapped()).to.eql({
+        foo: { param: 'foo', message: '2' },
+        bar: { param: 'bar', message: '1' }
+      });
+    });
+
+    it('should return first error for each param when firstErrorOnly is enabled', function() {
+      expect(this.result.useFirstErrorOnly().mapped()).to.eql({
+        foo: { param: 'foo', message: '1' },
+        bar: { param: 'bar', message: '1' }
+      });
+    });
+  });
+
+  describe('adds #useFirstErrorOnly() which', function() {
+    it('should return the result object itself', function() {
+      expect(this.result.useFirstErrorOnly()).to.equal(this.result);
+    });
+  });
+
+  describe('adds #throw() which', function() {
+    describe('there are errors', function() {
+      it('should throw error object', function() {
+        expect(this.result.throw).to.throw(Error);
+      });
+
+      it('should throw decorated object', function() {
+        try {
+          this.result.throw();
+        } catch (e) {
+          expect(e.array()).to.eql(this.result.array());
+        }
+      });
+    });
+
+    describe('there are no errors', function() {
+      it('should not do anything', function() {
+        var result = decorateAsValidationResult({}, []);
+        result.throw();
+      });
+    });
+  });
+});

--- a/test/getValidationErrorsTest.js
+++ b/test/getValidationErrorsTest.js
@@ -15,7 +15,7 @@ var errorMessage = 'Parameter is not 42';
 function validation(req, res) {
   req.checkQuery('testparam', errorMessage).notEmpty().isAsyncTest();
 
-  req.getValidationErrors().then(function(errors) {
+  req.getValidationResult().then(function(errors) {
     if (!errors.isEmpty()) {
       res.send(errors.array());
     } else {

--- a/test/getValidationErrorsTest.js
+++ b/test/getValidationErrorsTest.js
@@ -16,8 +16,8 @@ function validation(req, res) {
   req.checkQuery('testparam', errorMessage).notEmpty().isAsyncTest();
 
   req.getValidationErrors().then(function(errors) {
-    if (errors) {
-      res.send(errors);
+    if (!errors.isEmpty()) {
+      res.send(errors.array());
     } else {
       res.send({ testparam: req.query.testparam });
     }


### PR DESCRIPTION
Instead of returning the errors directly, the new method `#getValidationResult()` (previously `#getValidationErrors()`, see #269) will return a
result object which can be used to retrieve the errors in different ways.

- `#all()`: returns all errors
- `#mapped()`: returns a mapped version of the errors
- `#useFirstErrorOnly()`: determines that `#all()`/`#mapped()` will work with only the first error occurrence for each param
- `#throw()`: throws an `Error` with the same API as the result object

Tasks:
- [x] Develop the features
- [x] Update docs
- [x] Find a more suitable name instead of `#all()` (we're not really dealing with all errors sometimes...)

Closes #235, closes #223, closes #30 

---

**Bonus:** I reorganized lots of stuff in the docs!