### PR TITLE
Add TypeScript type definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 coverage
 .nyc_output
+build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change Log
 
+### upcoming 2016/12/09
+- [b2877ce](https://github.com/ctavan/express-validator/commit/b2877ce76a6ade87620db10091e335165b708628) Updated REAMDME, added tests for req.check with in: headers (@pascalopitz)
+- [28935b9](https://github.com/ctavan/express-validator/commit/28935b916de617cda9e80b58276c31f8079d975b) Adding checkHeaders schema functionality (@pascalopitz)
+- [c84820f](https://github.com/ctavan/express-validator/commit/c84820ff1b50bbeb7b82bb6c58bd08cc17541e49) Update changelog up to v3. (@rustybailey)
+
 ### v3.0.0 2016/11/24
 - [cdfb5dc](https://github.com/ctavan/express-validator/commit/cdfb5dc114bea4bfb481ae360406bc163496d3da) Upgrade to 3.0.0 (@gustavohenke)
 - [fa25f11](https://github.com/ctavan/express-validator/commit/fa25f11fe211663e902160b921db8e1eb7a07ce3) Specify fail message of optional when using schema (@gustavohenke)
@@ -109,12 +114,12 @@
 - [c704a22](https://github.com/ctavan/express-validator/commit/c704a2203f430dacff765e83862e36e1cc45471d) Upgrade to 2.19.2 (@rustybailey)
 - [9b74fb4](https://github.com/ctavan/express-validator/commit/9b74fb4ffd4edce7268b9d1e9303829cdb8ae14e) Fix matches example in README (resolves #209) (@rustybailey)
 - [20f033a](https://github.com/ctavan/express-validator/commit/20f033a9f6a7ba6ad1f3d9eb6c34e8e804071d0a) Added missing require that broke build of tests on node v0.10.43
-- [981239f](https://github.com/ctavan/express-validator/commit/981239fd7d7841b2c862c28e1d3f92836f52dcaa) Readme and tests updated after review.
+- [981239f](https://github.com/ctavan/express-validator/commit/981239fd7d7841b2c862c28e1d3f92836f52dcaa) Readme and tests updated after review. (@JaniszM)
 - [f6f88bc](https://github.com/ctavan/express-validator/commit/f6f88bcfd69179f2fdae87c02903bc04eba92029) #203 - Fixed bug where .withMessage() would not apply to a custom async validator (@chrissinclair)
-- [4fdc7a9](https://github.com/ctavan/express-validator/commit/4fdc7a9a711485e792886accdc9160725ad67d9b) Extended test schema to check if not supported location type force validator to skip.
-- [d1894e8](https://github.com/ctavan/express-validator/commit/d1894e88a15f5a135aaf6090e9a771eff0bbee48) Formatter updated.
-- [d87a4f1](https://github.com/ctavan/express-validator/commit/d87a4f1a06b98ef466513decec6428fef3d3c6d6) Readme updated.
-- [a300751](https://github.com/ctavan/express-validator/commit/a30075162b721c5cdb3c2dee196704aab3d30f5b) Issue #206. Added support for new field in validators structure allowing to define location of validation.
+- [4fdc7a9](https://github.com/ctavan/express-validator/commit/4fdc7a9a711485e792886accdc9160725ad67d9b) Extended test schema to check if not supported location type force validator to skip. (@JaniszM)
+- [d1894e8](https://github.com/ctavan/express-validator/commit/d1894e88a15f5a135aaf6090e9a771eff0bbee48) Formatter updated. (@JaniszM)
+- [d87a4f1](https://github.com/ctavan/express-validator/commit/d87a4f1a06b98ef466513decec6428fef3d3c6d6) Readme updated. (@JaniszM)
+- [a300751](https://github.com/ctavan/express-validator/commit/a30075162b721c5cdb3c2dee196704aab3d30f5b) Issue #206. Added support for new field in validators structure allowing to define location of validation. (@JaniszM)
 
 ### v2.19.1 2016/02/05
 - [f3ed152](https://github.com/ctavan/express-validator/commit/f3ed152ef28bcc49d7c67c3842fb1ff1bb2067ed) 2.19.1 (@rustybailey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 ## Change Log
 
-### upcoming 2016/12/09
-- [b2877ce](https://github.com/ctavan/express-validator/commit/b2877ce76a6ade87620db10091e335165b708628) Updated REAMDME, added tests for req.check with in: headers (@pascalopitz)
-- [28935b9](https://github.com/ctavan/express-validator/commit/28935b916de617cda9e80b58276c31f8079d975b) Adding checkHeaders schema functionality (@pascalopitz)
-- [c84820f](https://github.com/ctavan/express-validator/commit/c84820ff1b50bbeb7b82bb6c58bd08cc17541e49) Update changelog up to v3. (@rustybailey)
-
 ### v3.0.0 2016/11/24
 - [cdfb5dc](https://github.com/ctavan/express-validator/commit/cdfb5dc114bea4bfb481ae360406bc163496d3da) Upgrade to 3.0.0 (@gustavohenke)
 - [fa25f11](https://github.com/ctavan/express-validator/commit/fa25f11fe211663e902160b921db8e1eb7a07ce3) Specify fail message of optional when using schema (@gustavohenke)
@@ -114,12 +109,12 @@
 - [c704a22](https://github.com/ctavan/express-validator/commit/c704a2203f430dacff765e83862e36e1cc45471d) Upgrade to 2.19.2 (@rustybailey)
 - [9b74fb4](https://github.com/ctavan/express-validator/commit/9b74fb4ffd4edce7268b9d1e9303829cdb8ae14e) Fix matches example in README (resolves #209) (@rustybailey)
 - [20f033a](https://github.com/ctavan/express-validator/commit/20f033a9f6a7ba6ad1f3d9eb6c34e8e804071d0a) Added missing require that broke build of tests on node v0.10.43
-- [981239f](https://github.com/ctavan/express-validator/commit/981239fd7d7841b2c862c28e1d3f92836f52dcaa) Readme and tests updated after review. (@JaniszM)
+- [981239f](https://github.com/ctavan/express-validator/commit/981239fd7d7841b2c862c28e1d3f92836f52dcaa) Readme and tests updated after review.
 - [f6f88bc](https://github.com/ctavan/express-validator/commit/f6f88bcfd69179f2fdae87c02903bc04eba92029) #203 - Fixed bug where .withMessage() would not apply to a custom async validator (@chrissinclair)
-- [4fdc7a9](https://github.com/ctavan/express-validator/commit/4fdc7a9a711485e792886accdc9160725ad67d9b) Extended test schema to check if not supported location type force validator to skip. (@JaniszM)
-- [d1894e8](https://github.com/ctavan/express-validator/commit/d1894e88a15f5a135aaf6090e9a771eff0bbee48) Formatter updated. (@JaniszM)
-- [d87a4f1](https://github.com/ctavan/express-validator/commit/d87a4f1a06b98ef466513decec6428fef3d3c6d6) Readme updated. (@JaniszM)
-- [a300751](https://github.com/ctavan/express-validator/commit/a30075162b721c5cdb3c2dee196704aab3d30f5b) Issue #206. Added support for new field in validators structure allowing to define location of validation. (@JaniszM)
+- [4fdc7a9](https://github.com/ctavan/express-validator/commit/4fdc7a9a711485e792886accdc9160725ad67d9b) Extended test schema to check if not supported location type force validator to skip.
+- [d1894e8](https://github.com/ctavan/express-validator/commit/d1894e88a15f5a135aaf6090e9a771eff0bbee48) Formatter updated.
+- [d87a4f1](https://github.com/ctavan/express-validator/commit/d87a4f1a06b98ef466513decec6428fef3d3c6d6) Readme updated.
+- [a300751](https://github.com/ctavan/express-validator/commit/a30075162b721c5cdb3c2dee196704aab3d30f5b) Issue #206. Added support for new field in validators structure allowing to define location of validation.
 
 ### v2.19.1 2016/02/05
 - [f3ed152](https://github.com/ctavan/express-validator/commit/f3ed152ef28bcc49d7c67c3842fb1ff1bb2067ed) 2.19.1 (@rustybailey)

--- a/README.md
+++ b/README.md
@@ -527,14 +527,6 @@ So please uninstall the typings from DT. Otherwise they may cause conflicts
 
 See [CHANGELOG.md](CHANGELOG.md)
 
-## Contributors
-
-- [@ctavan](https://github.com/ctavan)- Wrap the gist in an npm package.
-- [@orfaust](https://github.com/orfaust) - Add `validationErrors()` and nested field support.
-- [@zero21xxx](https://github.com/zero21xxx) - Added `checkBody` function.
-- [@gustavohenke](https://github.com/gustavohenke) - Introduced validation result API.
-- [@IOAyman](https://github.com/IOAyman) - Added type definitions.
-
 ## License
 
 Copyright (c) 2010 Chris O'Hara <cohara87@gmail.com>, MIT License

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ An [express.js]( https://github.com/visionmedia/express ) middleware for
 - [Optional input](#optional-input)
 - [Sanitizer](#sanitizer)
 - [Regex routes](#regex-routes)
+- [TypeScript](#typescript)
 - [Changelog](#changelog)
 - [License](#license)
 
@@ -514,15 +515,25 @@ You can validate the extracted matches like this:
 req.assert(0, 'Not a three-digit integer.').len(3, 3).isInt();
 ```
 
+## TypeScript
+If you have been using this library with [TypeScript](http://www.typescriptlang.org/),
+you must have been using the type definitions from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e2af6d0/express-validator/express-validator.d.ts).
+
+However, as of v3.1.0, the type definitions are shipped with the library.
+So please uninstall the typings from DT. Otherwise they may cause conflicts
+
+
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md)
 
 ## Contributors
 
-- Christoph Tavan <dev@tavan.de> - Wrap the gist in an npm package
-- @orfaust - Add `validationErrors()` and nested field support
-- @zero21xxx - Added `checkBody` function
+- [@ctavan](https://github.com/ctavan)- Wrap the gist in an npm package.
+- [@orfaust](https://github.com/orfaust) - Add `validationErrors()` and nested field support.
+- [@zero21xxx](https://github.com/zero21xxx) - Added `checkBody` function.
+- [@gustavohenke](https://github.com/gustavohenke) - Introduced validation result API.
+- [@IOAyman](https://github.com/IOAyman) - Added type definitions.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,10 @@ declare module "express-validator" {
 declare namespace ExpressValidator {
 
   interface ValidatorFunction { (item: string | {}, message?: string): Validator; }
+  /**
+   * This one's used for RegexRoutes
+   * @see https://github.com/ctavan/express-validator#regex-routes
+   */
   interface ValidatorExtraFunction extends ValidatorFunction { (matchIndex: number, message?: string): Validator; }
   interface SanitizerFunction { (item: string): Sanitizer; }
   interface Dictionary<T> { [key: string]: T; }
@@ -67,7 +71,7 @@ declare namespace ExpressValidator {
     validate: ValidatorExtraFunction;
     check: ValidatorExtraFunction;
     checkBody: ValidatorFunction;
-    checkFiles: ValidatorFunction;
+    checkCookies: ValidatorFunction;
     checkHeaders: ValidatorFunction;
     checkParams: ValidatorFunction;
     checkQuery: ValidatorFunction;
@@ -78,6 +82,7 @@ declare namespace ExpressValidator {
     sanitizeQuery: SanitizerFunction;
     sanitizeParams: SanitizerFunction;
     sanitizeHeaders: SanitizerFunction;
+    sanitizeCookies: SanitizerFunction;
 
     /**
      * @deprecated
@@ -277,7 +282,7 @@ declare namespace ExpressValidator.Options {
   }
 
   interface IsIntOptions extends MinMaxExtendedOptions {
-    allow_leading_zeroes: boolean;
+    allow_leading_zeroes?: boolean;
   }
 
   /**
@@ -311,10 +316,10 @@ declare namespace ExpressValidator.Options {
    * }
    */
   interface IsURLOptions {
-    protocols?: string[];
+    protocols?: string[]; // TODO Protocol type
     require_tld?: boolean;
     require_protocol?: boolean;
-    require_host: boolean;
+    require_host?: boolean;
     require_valid_protocol?: boolean;
     allow_underscores?: boolean;
     host_whitelist?: (string | RegExp)[];
@@ -345,8 +350,8 @@ declare namespace ExpressValidator.Options {
    * }
    */
   interface IsISSNOptions {
-    case_sensitive: boolean
-    require_hyphen: boolean
+    case_sensitive?: boolean
+    require_hyphen?: boolean
   }
 
   /**
@@ -405,16 +410,16 @@ declare namespace ExpressValidator.Options {
    * }
    */
   interface NormalizeEmailOptions {
-    all_lowercase: boolean
-    gmail_lowercase: boolean
-    gmail_remove_dots: boolean
-    gmail_remove_subaddress: boolean
-    gmail_convert_googlemaildotcom: boolean
-    outlookdotcom_lowercase: boolean
-    outlookdotcom_remove_subaddress: boolean
-    yahoo_lowercase: boolean
-    yahoo_remove_subaddress: boolean
-    icloud_lowercase: boolean
-    icloud_remove_subaddress: boolean
+    all_lowercase?: boolean
+    gmail_lowercase?: boolean
+    gmail_remove_dots?: boolean
+    gmail_remove_subaddress?: boolean
+    gmail_convert_googlemaildotcom?: boolean
+    outlookdotcom_lowercase?: boolean
+    outlookdotcom_remove_subaddress?: boolean
+    yahoo_lowercase?: boolean
+    yahoo_remove_subaddress?: boolean
+    icloud_lowercase?: boolean
+    icloud_remove_subaddress?: boolean
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,8 @@ declare namespace Express {
 declare module "express-validator" {
 
   /**
-   * @middlewareOptions see: https://github.com/ctavan/express-validator#middleware-options
+   * @param options see: https://github.com/ctavan/express-validator#middleware-options
+   * @constructor
    */
   function ExpressValidator(options?: ExpressValidator.ExpressValidatorOptions): express.RequestHandler;
 
@@ -29,10 +30,33 @@ declare namespace ExpressValidator {
   interface SanitizerFunction { (item: string): Sanitizer; }
   interface Dictionary<T> { [key: string]: T; }
   interface Result {
+    /**
+     * @return A boolean determining whether there were errors or not.
+     */
     isEmpty(): boolean
+    /**
+     * @return All errors for all validated parameters will be included, unless you specify that you want only the first
+     * error of each param by invoking `result.useFirstErrorOnly()`.
+     */
     array(): MappedError[]
+    /**
+     * @return An object of errors, where the key is the parameter name, and the value is an error object as returned by
+     *  the error formatter.
+     * Because of historical reasons, by default this method will return the last error of each parameter.
+     * You can change this behavior by invoking result.useFirstErrorOnly(), so the first error is returned instead.
+     */
     mapped(): Dictionary<MappedError>
+    /**
+     * Sets the `firstErrorOnly` flag of this result object, which modifies the way other methods like `result.array()`
+     * and `result.mapped()` work.
+     */
     useFirstErrorOnly(): Result
+    /**
+     * Useful for dealing with the validation errors in the catch block of a try..catch or promise.
+     *
+     * @throws If there are errors, throws an Error object which is decorated with the same API as the validation
+     * result object.
+     */
     throw(): Result
   }
 
@@ -53,8 +77,31 @@ declare namespace ExpressValidator {
     sanitizeParams: SanitizerFunction;
     sanitizeHeaders: SanitizerFunction;
 
+    /**
+     * @deprecated
+     * @param mapped Will cause the validator to return an object that maps parameter to error.
+     * @return Synchronous errors in the form of an array. If there are no errors, the returned value is false.
+     */
+    validationErrors(mapped?: boolean): Dictionary<MappedError> | MappedError[];
+    /**
+     * @deprecated
+     * @param mapped Will cause the validator to return an object that maps parameter to error.
+     * @return Synchronous errors in the form of an array. If there are no errors, the returned value is false.
+     */
+    validationErrors<T>(mapped?: boolean): Dictionary<T> | T[];
+    /**
+     * @deprecated
+     * @param mapped Whether to map parameters to errors or not.
+     */
     asyncValidationErrors(mapped?: boolean): Promise<MappedError[] | Dictionary<MappedError>>;
+    /**
+     * @deprecated
+     * @param mapped Whether to map parameters to errors or not.
+     */
     asyncValidationErrors<T>(mapped?: boolean): Promise<T[] | Dictionary<T>>;
+    /**
+     * @return Promise<Result> A Promise which resolves to a result object.
+     */
     getValidationResult(): Promise<Result>
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,11 +129,11 @@ declare namespace ExpressValidator {
     isVariableWidth(): Validator;
     isMultibyte(): Validator;
     isSurrogatePair(): Validator;
-    isInt(options?: MinMaxOptions): Validator;
+    isInt(options?: ExpressValidator.Options.MinMaxOptions): Validator;
     /**
      * Alias for isDecimal
      */
-    isFloat(options?: MinMaxOptions): Validator;
+    isFloat(options?: ExpressValidator.Options.MinMaxOptions): Validator;
     isDecimal(): Validator;
     isHexadecimal(): Validator;
     isDivisibleBy(num: number): Validator;
@@ -147,8 +147,8 @@ declare namespace ExpressValidator {
      * Check if length is 0
      */
     isEmpty(): Validator;
-    isLength(options: MinMaxOptions): Validator;
-    isByteLength(options: MinMaxOptions): Validator;
+    isLength(options: ExpressValidator.Options.MinMaxOptions): Validator;
+    isByteLength(options: ExpressValidator.Options.MinMaxOptions): Validator;
     /**
      * Version can be 3, 4, 5, 'all' or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
      */
@@ -195,62 +195,47 @@ declare namespace ExpressValidator {
     // Additional ValidatorChain.prototype.* validators
 
     notEmpty(): Validator;
-    len(options: MinMaxOptions): Validator;
+    len(options: ExpressValidator.Options.MinMaxOptions): Validator;
     optional(options?: { checkFalsy?: boolean }): Validator;
     withMessage(message: string): Validator;
   }
 
   interface Sanitizer {
     /**
-     * Trim optional `chars`, default is to trim whitespace (\r\n\t )
+     * Convert the input string to a date, or null if the input is not a date.
      */
-    trim(...chars: string[]): Sanitizer;
-    ltrim(...chars: string[]): Sanitizer;
-    rtrim(...chars: string[]): Sanitizer;
-    stripLow(keep_new_lines?: boolean): Sanitizer;
+    toDate(): Sanitizer;
     toFloat(): Sanitizer;
     toInt(radix?: number): Sanitizer;
     /**
      * True unless str = '0', 'false', or str.length == 0. In strict mode only '1' and 'true' return true.
      */
     toBoolean(strict?: boolean): Sanitizer;
-
     /**
-     * Convert the input string to a date, or null if the input is not a date.
+     * Trim optional `chars`, default is to trim whitespace (\r\n\t )
      */
-    toDate(): Sanitizer;
-
+    trim(chars: string): Sanitizer;
+    ltrim(chars: string): Sanitizer;
+    rtrim(chars: string): Sanitizer;
+    stripLow(keep_new_lines?: boolean): Sanitizer;
     /**
      * Escape &, <, >, and "
      */
     escape(): Sanitizer;
-
     /**
      * Replaces HTML encoded entities with <, >, &, ', " and /.
      */
     unescape(): Sanitizer;
-
     blacklist(chars: string): Sanitizer;
-    blacklist(chars: string[]): Sanitizer;
     whitelist(chars: string): Sanitizer;
-    whitelist(chars: string[]): Sanitizer;
 
-    normalizeEmail(options?: { lowercase?: boolean; remove_dots?: boolean; remove_extensions?: boolean }): Sanitizer;
-
-    /**
-     * !!! XSS sanitization was removed from the library (see: https://github.com/chriso/validator.js#xss-sanitization)
-     */
+    normalizeEmail(options?: ExpressValidator.Options.NormalizeEmailOptions): Sanitizer;
   }
 
   interface MappedError {
     param: string;
     msg: string;
     value: string;
-  }
-
-  interface MinMaxOptions {
-    min?: number;
-    max?: number;
   }
 }
 
@@ -263,6 +248,11 @@ declare namespace ExpressValidator.Options {
   }
 
   // VALIDATORS
+
+  interface MinMaxOptions {
+    min?: number;
+    max?: number;
+  }
 
   interface IsEmailOptions {
     allow_display_name?: boolean;
@@ -311,4 +301,18 @@ declare namespace ExpressValidator.Options {
 
 
   // SANITIZERS
+
+  interface NormalizeEmailOptions {
+    all_lowercase: boolean
+    gmail_lowercase: boolean
+    gmail_remove_dots: boolean
+    gmail_remove_subaddress: boolean
+    gmail_convert_googlemaildotcom: boolean
+    outlookdotcom_lowercase: boolean
+    outlookdotcom_remove_subaddress: boolean
+    yahoo_lowercase: boolean
+    yahoo_remove_subaddress: boolean
+    icloud_lowercase: boolean
+    icloud_remove_subaddress: boolean
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module "express-validator" {
    * @param options see: https://github.com/ctavan/express-validator#middleware-options
    * @constructor
    */
-  function ExpressValidator(options?: ExpressValidator.ExpressValidatorOptions): express.RequestHandler;
+  function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;
 
   export = ExpressValidator;
 }
@@ -106,100 +106,54 @@ declare namespace ExpressValidator {
   }
 
   export interface Validator {
-    /**
-     * Alias for regex()
-     */
-    is(): Validator;
-    /**
-     * Alias for notRegex()
-     */
-    not(): Validator;
-    isEmail(options?: {}): Validator;
+    isEmail(options?: ExpressValidator.Options.IsEmailOptions): Validator;
     /**
      * Accepts http, https, ftp
      */
-    isURL(): Validator;
-    isFQDN(options?: MinMaxOptions): Validator;
-
+    isURL(options?: ExpressValidator.Options.IsURLOptions): Validator;
+    isMACAddress(): Validator;
     /**
      * Combines isIPv4 and isIPv6
      */
-    isIP(): Validator;
-    isIPv4(): Validator;
-    isIPv6(): Validator;
-    isMACAddress(): Validator;
-    isISBN(version?: number): Validator;
-    isISIN(): Validator;
-    isISO8601(): Validator;
-    isMobilePhone(locale: string): Validator;
-    isMongoId(): Validator;
-    isMultibyte(): Validator;
-    isAlpha(locale?: string): Validator;
-    isAlphanumeric(locale?: string): Validator;
-    isAscii(): Validator;
-    isBase64(): Validator;
+    isIP(version?: number): Validator;
+    isFQDN(options?: ExpressValidator.Options.IsFQDNOptions): Validator;
     isBoolean(): Validator;
-    isByteLength(options: MinMaxOptions): Validator;
-    isCurrency(options: {}): Validator;
-    isDataURI(): Validator;
-    isDivisibleBy(num: number): Validator;
+    isAlpha(locale?: string): Validator; // TODO AlphaLocale type
+    isAlphanumeric(locale?: string): Validator; // TODO AlphanumericLocale type
     isNumeric(): Validator;
+    isLowercase(): Validator;
+    isUppercase(): Validator;
+    isAscii(): Validator;
+    isFullWidth(): Validator;
+    isHalfWidth(): Validator;
+    isVariableWidth(): Validator;
+    isMultibyte(): Validator;
+    isSurrogatePair(): Validator;
+    isInt(options?: MinMaxOptions): Validator;
+    /**
+     * Alias for isDecimal
+     */
+    isFloat(options?: MinMaxOptions): Validator;
+    isDecimal(): Validator;
     isHexadecimal(): Validator;
+    isDivisibleBy(num: number): Validator;
     /**
      * Accepts valid hexcolors with or without # prefix
      */
     isHexColor(): Validator;
-    /**
-     * isNumeric accepts zero padded numbers, e.g. '001', isInt doesn't
-     */
-    isInt(options?: MinMaxOptions): Validator;
-    isLowercase(): Validator;
-    isUppercase(): Validator;
-    isDecimal(): Validator;
-    /**
-     * Alias for isDecimal
-     */
-    isFloat(): Validator;
-    isFullWidth(): Validator;
-    isHalfWidth(): Validator;
-    isVariableWidth(): Validator;
+    isMD5(): Validator;
+    isJSON(): Validator;
     /**
      * Check if length is 0
      */
-    isNull(): Validator;
+    isEmpty(): Validator;
+    isLength(options: MinMaxOptions): Validator;
+    isByteLength(options: MinMaxOptions): Validator;
     /**
-     * Not just whitespace (input.trim().length !== 0)
+     * Version can be 3, 4, 5, 'all' or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
      */
-    notEmpty(): Validator;
-    equals(equals: any): Validator;
-    contains(str: string): Validator;
-
-    /**
-     * Usage: matches(/[a-z]/i) or matches('[a-z]','i')
-     */
-    matches(pattern: string, modifiers?: string): Validator;
-    matches(pattern: RegExp): Validator;
-
-    /**
-     * max is optional
-     */
-    len(min: number, max?: number): Validator;
-    /**
-     * Version can be 3, 4 or 5 or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
-     */
-    isUUID(version?: number): Validator;
-    /**
-     * Alias for isUUID(3)
-     */
-    isUUIDv3(): Validator;
-    /**
-     * Alias for isUUID(4)
-     */
-    isUUIDv4(): Validator;
-    /**
-     * Alias for isUUID(5)
-     */
-    isUUIDv5(): Validator;
+    isUUID(version?: number | string): Validator; // TODO UUID version type
+    isMongoId(): Validator;
     /**
      * Uses Date.parse() - regex is probably a better choice
      */
@@ -212,24 +166,36 @@ declare namespace ExpressValidator {
      * Argument is optional and defaults to today. Comparison is non-inclusive
      */
     isBefore(date?: Date): Validator;
-    isIn(options: string): Validator;
-    isIn(options: string[]): Validator;
-    notIn(options: string): Validator;
-    notIn(options: string[]): Validator;
-    max(val: string): Validator;
-    min(val: string): Validator;
-    isJSON(): Validator;
-    isLength(options: MinMaxOptions): Validator;
-    isWhitelisted(chars: string): Validator;
+    isIn(options: string | string[]): Validator;
     /**
      * Will work against Visa, MasterCard, American Express, Discover, Diners Club, and JCB card numbering formats
      */
     isCreditCard(): Validator;
-    /**
-     * Check an input only when the input exists
-     */
-    isSurrogatePar(): Validator;
+    isISIN(): Validator;
+    isISBN(version?: number): Validator;
+    isISSN(options?: ExpressValidator.Options.IsISSNOptions): Validator
+    isMobilePhone(locale: string): Validator; // TODO MobilePhoneLocale
+    isCurrency(options: ExpressValidator.Options.IsCurrencyOptions): Validator;
+    isISO8601(): Validator;
+    isBase64(): Validator;
+    isDataURI(): Validator;
+    isWhitelisted(chars: string | string[]): Validator;
 
+
+    // Additional Validators provided by validator.js
+
+    equals(equals: any): Validator;
+    contains(str: string): Validator;
+    /**
+     * Usage: matches(/[a-z]/i) or matches('[a-z]','i')
+     */
+    matches(str: string, pattern: RegExp | string, modifiers?: string): Validator;
+
+
+    // Additional ValidatorChain.prototype.* validators
+
+    notEmpty(): Validator;
+    len(options: MinMaxOptions): Validator;
     optional(options?: { checkFalsy?: boolean }): Validator;
     withMessage(message: string): Validator;
   }
@@ -286,10 +252,63 @@ declare namespace ExpressValidator {
     min?: number;
     max?: number;
   }
+}
+
+declare namespace ExpressValidator.Options {
 
   export interface ExpressValidatorOptions {
     customValidators: { [validatorName: string]: (value: any) => boolean }
     customSanitizers: { [sanitizername: string]: (value: any) => any }
     errorFormatter: (param: string, msg: string, value: any) => {param: string, msg: string, value: any}
   }
+
+  // VALIDATORS
+
+  interface IsEmailOptions {
+    allow_display_name?: boolean;
+    allow_utf8_local_part?: boolean;
+    require_tld?: boolean;
+  }
+
+  interface IsURLOptions {
+    protocols?: string[];
+    require_tld?: boolean;
+    require_protocol?: boolean;
+    require_host: boolean;
+    require_valid_protocol?: boolean;
+    allow_underscores?: boolean;
+    host_whitelist?: (string | RegExp)[];
+    host_blacklist?: (string | RegExp)[];
+    allow_trailing_dot?: boolean;
+    allow_protocol_relative_urls?: boolean;
+  }
+
+  interface IsFQDNOptions {
+    require_tld?: boolean;
+    allow_underscores?: boolean;
+    allow_trailing_dot?: boolean;
+  }
+
+  interface IsISSNOptions {
+    case_sensitive: boolean
+    require_hyphen: boolean
+  }
+
+  interface IsCurrencyOptions {
+    symbol?: string;
+    require_symbol?: boolean;
+    allow_space_after_symbol?: boolean;
+    symbol_after_digits?: boolean;
+    allow_negatives?: boolean;
+    parens_for_negatives?: boolean;
+    negative_sign_before_digits?: boolean;
+    negative_sign_after_digits?: boolean;
+    allow_negative_sign_placeholder?: boolean;
+    thousands_separator?: string;
+    decimal_separator?: string;
+    allow_space_after_digits?: boolean;
+  }
+
+
+  // SANITIZERS
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/ctavan/express-validator
 // Definitions by: Ayman Nedjmeddine <https://github.com/IOAyman>, Nathan Ridley <https://github.com/axefrog/>, Jonathan Häberle <http://dreampulse.de>, Peter Harris <https://github.com/codeanimal/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-import * as express from 'express'
-import * as Promise from 'bluebird'
+
+///<reference types="express"/>
+///<reference types="bluebird"/>
 
 // Add RequestValidation Interface on to Express's Request Interface.
 declare namespace Express {
@@ -12,6 +13,7 @@ declare namespace Express {
 
 // External express-validator module.
 declare module "express-validator" {
+  import express = require('express');
 
   /**
    * @param options see: https://github.com/ctavan/express-validator#middleware-options
@@ -257,9 +259,9 @@ declare namespace ExpressValidator {
 declare namespace ExpressValidator.Options {
 
   export interface ExpressValidatorOptions {
-    customValidators: { [validatorName: string]: (value: any) => boolean }
-    customSanitizers: { [sanitizername: string]: (value: any) => any }
-    errorFormatter: (param: string, msg: string, value: any) => {param: string, msg: string, value: any}
+    customValidators?: { [validatorName: string]: (value: any) => boolean }
+    customSanitizers?: { [sanitizername: string]: (value: any) => any }
+    errorFormatter?: (param: string, msg: string, value: any) => {param: string, msg: string, value: any}
   }
 
   // VALIDATORS

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,8 @@ declare namespace ExpressValidator {
   export type MobilePhoneLocal = 'ar-DZ' | 'ar-SA' | 'ar-SY' | 'cs-CZ' | 'de-DE' | 'da-DK' | 'el-GR' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-CA' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fi-FI' | 'fr-FR' | 'hu-HU' | 'it-IT' | 'ja-JP' | 'ms-MY' | 'nb-NO' | 'nn-NO' | 'pl-PL' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'tr-TR' | 'vi-VN' | 'zh-CN' | 'zh-TW'
 
 
-  interface ValidatorFunction { (item: string | {}, message?: string): Validator; }
+  interface ValidatorFunction { (item: string | string[], message?: string): Validator; }
+  interface ValidatorFunction { (schema: {}): Validator; }
   /**
    * This one's used for RegexRoutes
    * @see https://github.com/ctavan/express-validator#regex-routes

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,11 +129,11 @@ declare namespace ExpressValidator {
     isVariableWidth(): Validator;
     isMultibyte(): Validator;
     isSurrogatePair(): Validator;
-    isInt(options?: ExpressValidator.Options.MinMaxOptions): Validator;
+    isInt(options?: ExpressValidator.Options.IsIntOptions): Validator;
     /**
      * Alias for isDecimal
      */
-    isFloat(options?: ExpressValidator.Options.MinMaxOptions): Validator;
+    isFloat(options?: ExpressValidator.Options.MinMaxExtendedOptions): Validator;
     isDecimal(): Validator;
     isHexadecimal(): Validator;
     isDivisibleBy(num: number): Validator;
@@ -252,6 +252,15 @@ declare namespace ExpressValidator.Options {
   interface MinMaxOptions {
     min?: number;
     max?: number;
+  }
+
+  interface MinMaxExtendedOptions extends MinMaxOptions {
+    lt?: number;
+    gt?: number;
+  }
+
+  interface IsIntOptions extends MinMaxExtendedOptions {
+    allow_leading_zeroes: boolean;
   }
 
   interface IsEmailOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,10 +32,19 @@ declare namespace ExpressValidator {
   export type AlphaLocale = 'ar' | 'ar-AE' | 'ar-BH' | 'ar-DZ' | 'ar-EG' | 'ar-IQ' | 'ar-JO' | 'ar-KW' | 'ar-LB' | 'ar-LY' | 'ar-MA' | 'ar-QA' | 'ar-QM' | 'ar-SA' | 'ar-SD' | 'ar-SY' | 'ar-TN' | 'ar-YE' | 'cs-CZ' | 'da-DK' | 'de-DE' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fr-FR' | 'hu-HU' | 'nl-NL' | 'pl-PL' | 'pt-BR' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'sr-RS@latin' | 'tr-TR' | 'uk-UA'
   export type AlphanumericLocale = 'ar' | 'ar-AE' | 'ar-BH' | 'ar-DZ' | 'ar-EG' | 'ar-IQ' | 'ar-JO' | 'ar-KW' | 'ar-LB' | 'ar-LY' | 'ar-MA' | 'ar-QA' | 'ar-QM' | 'ar-SA' | 'ar-SD' | 'ar-SY' | 'ar-TN' | 'ar-YE' | 'cs-CZ' | 'da-DK' | 'de-DE' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fr-FR' | 'fr-BE' | 'hu-HU' | 'nl-BE' | 'nl-NL' | 'pl-PL' | 'pt-BR' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'sr-RS@latin' | 'tr-TR' | 'uk-UA'
   export type MobilePhoneLocal = 'ar-DZ' | 'ar-SA' | 'ar-SY' | 'cs-CZ' | 'de-DE' | 'da-DK' | 'el-GR' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-CA' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fi-FI' | 'fr-FR' | 'hu-HU' | 'it-IT' | 'ja-JP' | 'ms-MY' | 'nb-NO' | 'nn-NO' | 'pl-PL' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'tr-TR' | 'vi-VN' | 'zh-CN' | 'zh-TW'
+  export type Location = 'body' | 'params' | 'query' | 'headers' // TODO add cookies if #292 is accepted
 
+  export type ValidationSchema = {
+    [param: string]:
+      ExpressValidator.Options.ValidationSchemaParamOptions // standard validators
+      | // or
+      { [customValidator: string]: ExpressValidator.Options.ValidatorSchemaOptions } // custom ones
+  }
 
-  interface ValidatorFunction { (item: string | string[], message?: string): Validator; }
-  interface ValidatorFunction { (schema: {}): Validator; }
+  interface ValidatorFunction {
+    (item: string | string[], message?: string): Validator;
+    (schema: {}): Validator;
+  }
   /**
    * This one's used for RegexRoutes
    * @see https://github.com/ctavan/express-validator#regex-routes
@@ -121,6 +130,13 @@ declare namespace ExpressValidator {
   }
 
   export interface Validator {
+
+    /*
+     * Hi fellow contributor,
+     * TODO if you add a validator here, please add it also to ValidationSchemaParamOptions
+     * preferably in the same order/position, just to make it easier for comparision.
+     */
+
     isEmail(options?: ExpressValidator.Options.IsEmailOptions): Validator;
     isURL(options?: ExpressValidator.Options.IsURLOptions): Validator;
     isMACAddress(): Validator;
@@ -276,6 +292,74 @@ declare namespace ExpressValidator.Options {
     customSanitizers?: { [sanitizername: string]: (value: any) => any }
     errorFormatter?: (param: string, msg: string, value: any) => {param: string, msg: string, value: any}
   }
+
+
+  interface ValidatorSchemaOptions {
+    options?: any[]
+    errorMessage?: string
+  }
+
+  interface ValidationSchemaParamOptions {
+    in?: Location
+    errorMessage?: string
+
+    // Additional ValidatorChain.prototype.* validators
+    optional?: boolean | { checkFalsy: boolean }
+    notEmpty?: boolean | { errorMessage: string }
+    len?: ValidatorSchemaOptions
+
+    // exported from validator.js
+    isEmail?: ValidatorSchemaOptions
+    isURL?: ValidatorSchemaOptions
+    isMACAddress?: ValidatorSchemaOptions
+    isIP?: ValidatorSchemaOptions
+    isFQDN?: ValidatorSchemaOptions
+    isBoolean?: ValidatorSchemaOptions
+    isAlpha?: ValidatorSchemaOptions
+    isAlphanumeric?: ValidatorSchemaOptions
+    isNumeric?: ValidatorSchemaOptions
+    isLowercase?: ValidatorSchemaOptions
+    isUppercase?: ValidatorSchemaOptions
+    isAscii?: ValidatorSchemaOptions
+    isFullWidth?: ValidatorSchemaOptions
+    isHalfWidth?: ValidatorSchemaOptions
+    isVariableWidth?: ValidatorSchemaOptions
+    isMultibyte?: ValidatorSchemaOptions
+    isSurrogatePair?: ValidatorSchemaOptions
+    isInt?: ValidatorSchemaOptions
+    isFloat?: ValidatorSchemaOptions
+    isDecimal?: ValidatorSchemaOptions
+    isHexadecimal?: ValidatorSchemaOptions
+    isDivisibleBy?: ValidatorSchemaOptions
+    isHexColor?: ValidatorSchemaOptions
+    isMD5?: ValidatorSchemaOptions
+    isJSON?: ValidatorSchemaOptions
+    isEmpty?: ValidatorSchemaOptions
+    isLength?: ValidatorSchemaOptions
+    isByteLength?: ValidatorSchemaOptions
+    isUUID?: ValidatorSchemaOptions
+    isMongoId?: ValidatorSchemaOptions
+    isDate?: ValidatorSchemaOptions
+    isAfter?: ValidatorSchemaOptions
+    isBefore?: ValidatorSchemaOptions
+    isIn?: ValidatorSchemaOptions
+    isCreditCard?: ValidatorSchemaOptions
+    isISIN?: ValidatorSchemaOptions
+    isISBN?: ValidatorSchemaOptions
+    isISSN?: ValidatorSchemaOptions
+    isMobilePhone?: ValidatorSchemaOptions
+    isCurrency?: ValidatorSchemaOptions
+    isISO8601?: ValidatorSchemaOptions
+    isBase64?: ValidatorSchemaOptions
+    isDataURI?: ValidatorSchemaOptions
+    isWhitelisted?: ValidatorSchemaOptions
+
+    // Additional Validators provided by validator.js
+    equals?: ValidatorSchemaOptions
+    contains?: ValidatorSchemaOptions
+    matches?: ValidatorSchemaOptions
+  }
+
 
   // VALIDATORS
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,12 +27,19 @@ declare module "express-validator" {
 // Internal Module.
 declare namespace ExpressValidator {
 
+  export type URLProtocol = 'http' | 'https' | 'ftp'
+  export type UUIDVersion = 3 | 4 | 5 | 'all'
+  export type AlphaLocale = 'ar' | 'ar-AE' | 'ar-BH' | 'ar-DZ' | 'ar-EG' | 'ar-IQ' | 'ar-JO' | 'ar-KW' | 'ar-LB' | 'ar-LY' | 'ar-MA' | 'ar-QA' | 'ar-QM' | 'ar-SA' | 'ar-SD' | 'ar-SY' | 'ar-TN' | 'ar-YE' | 'cs-CZ' | 'da-DK' | 'de-DE' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fr-FR' | 'hu-HU' | 'nl-NL' | 'pl-PL' | 'pt-BR' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'sr-RS@latin' | 'tr-TR' | 'uk-UA'
+  export type AlphanumericLocale = 'ar' | 'ar-AE' | 'ar-BH' | 'ar-DZ' | 'ar-EG' | 'ar-IQ' | 'ar-JO' | 'ar-KW' | 'ar-LB' | 'ar-LY' | 'ar-MA' | 'ar-QA' | 'ar-QM' | 'ar-SA' | 'ar-SD' | 'ar-SY' | 'ar-TN' | 'ar-YE' | 'cs-CZ' | 'da-DK' | 'de-DE' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fr-FR' | 'fr-BE' | 'hu-HU' | 'nl-BE' | 'nl-NL' | 'pl-PL' | 'pt-BR' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'sr-RS@latin' | 'tr-TR' | 'uk-UA'
+  export type MobilePhoneLocal = 'ar-DZ' | 'ar-SA' | 'ar-SY' | 'cs-CZ' | 'de-DE' | 'da-DK' | 'el-GR' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-CA' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fi-FI' | 'fr-FR' | 'hu-HU' | 'it-IT' | 'ja-JP' | 'ms-MY' | 'nb-NO' | 'nn-NO' | 'pl-PL' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'tr-TR' | 'vi-VN' | 'zh-CN' | 'zh-TW'
+
+
   interface ValidatorFunction { (item: string | {}, message?: string): Validator; }
   /**
    * This one's used for RegexRoutes
    * @see https://github.com/ctavan/express-validator#regex-routes
    */
-  interface ValidatorExtraFunction extends ValidatorFunction { (matchIndex: number, message?: string): Validator; }
+  interface ValidatorFunctionRegExp extends ValidatorFunction { (matchIndex: number, message?: string): Validator; }
   interface SanitizerFunction { (item: string): Sanitizer; }
   interface Dictionary<T> { [key: string]: T; }
   interface Result {
@@ -67,9 +74,9 @@ declare namespace ExpressValidator {
   }
 
   export interface RequestValidation {
-    assert: ValidatorExtraFunction;
-    validate: ValidatorExtraFunction;
-    check: ValidatorExtraFunction;
+    assert: ValidatorFunctionRegExp;
+    validate: ValidatorFunctionRegExp;
+    check: ValidatorFunctionRegExp;
     checkBody: ValidatorFunction;
     checkCookies: ValidatorFunction;
     checkHeaders: ValidatorFunction;
@@ -123,8 +130,8 @@ declare namespace ExpressValidator {
     isIP(version?: number): Validator;
     isFQDN(options?: ExpressValidator.Options.IsFQDNOptions): Validator;
     isBoolean(): Validator;
-    isAlpha(locale?: string): Validator; // TODO AlphaLocale type
-    isAlphanumeric(locale?: string): Validator; // TODO AlphanumericLocale type
+    isAlpha(locale?: AlphaLocale): Validator;
+    isAlphanumeric(locale?: AlphanumericLocale): Validator;
     isNumeric(): Validator;
     isLowercase(): Validator;
     isUppercase(): Validator;
@@ -149,7 +156,7 @@ declare namespace ExpressValidator {
      * @param version 3, 4, 5 or 'all'. Default is 'all'.
      * @see http://en.wikipedia.org/wiki/Universally_unique_identifier
      */
-    isUUID(version?: number | string): Validator; // TODO UUID version type
+    isUUID(version?: UUIDVersion): Validator;
     /**
      * @see https://docs.mongodb.com/manual/reference/bson-types/#objectid
      */
@@ -176,7 +183,7 @@ declare namespace ExpressValidator {
      * @see https://en.wikipedia.org/wiki/International_Standard_Serial_Number
      */
     isISSN(options?: ExpressValidator.Options.IsISSNOptions): Validator
-    isMobilePhone(locale: string): Validator; // TODO MobilePhoneLocale
+    isMobilePhone(locale: MobilePhoneLocal): Validator;
     isCurrency(options: ExpressValidator.Options.IsCurrencyOptions): Validator;
     /**
      * @see https://en.wikipedia.org/wiki/ISO_8601
@@ -316,7 +323,7 @@ declare namespace ExpressValidator.Options {
    * }
    */
   interface IsURLOptions {
-    protocols?: string[]; // TODO Protocol type
+    protocols?: URLProtocol[];
     require_tld?: boolean;
     require_protocol?: boolean;
     require_host?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -107,13 +107,11 @@ declare namespace ExpressValidator {
 
   export interface Validator {
     isEmail(options?: ExpressValidator.Options.IsEmailOptions): Validator;
-    /**
-     * Accepts http, https, ftp
-     */
     isURL(options?: ExpressValidator.Options.IsURLOptions): Validator;
     isMACAddress(): Validator;
     /**
-     * Combines isIPv4 and isIPv6
+     *
+     * @param version IP version number 4 or 6
      */
     isIP(version?: number): Validator;
     isFQDN(options?: ExpressValidator.Options.IsFQDNOptions): Validator;
@@ -130,54 +128,60 @@ declare namespace ExpressValidator {
     isMultibyte(): Validator;
     isSurrogatePair(): Validator;
     isInt(options?: ExpressValidator.Options.IsIntOptions): Validator;
-    /**
-     * Alias for isDecimal
-     */
     isFloat(options?: ExpressValidator.Options.MinMaxExtendedOptions): Validator;
     isDecimal(): Validator;
     isHexadecimal(): Validator;
     isDivisibleBy(num: number): Validator;
-    /**
-     * Accepts valid hexcolors with or without # prefix
-     */
     isHexColor(): Validator;
     isMD5(): Validator;
     isJSON(): Validator;
-    /**
-     * Check if length is 0
-     */
     isEmpty(): Validator;
     isLength(options: ExpressValidator.Options.MinMaxOptions): Validator;
     isByteLength(options: ExpressValidator.Options.MinMaxOptions): Validator;
     /**
-     * Version can be 3, 4, 5, 'all' or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
+     * @param version 3, 4, 5 or 'all'. Default is 'all'.
+     * @see http://en.wikipedia.org/wiki/Universally_unique_identifier
      */
     isUUID(version?: number | string): Validator; // TODO UUID version type
-    isMongoId(): Validator;
     /**
-     * Uses Date.parse() - regex is probably a better choice
+     * @see https://docs.mongodb.com/manual/reference/bson-types/#objectid
      */
+    isMongoId(): Validator;
     isDate(): Validator;
     /**
-     * Argument is optional and defaults to today. Comparison is non-inclusive
+     * @param date Optional. Default to now.
      */
     isAfter(date?: Date): Validator;
     /**
-     * Argument is optional and defaults to today. Comparison is non-inclusive
+     * @param date Optional. Default to now.
      */
     isBefore(date?: Date): Validator;
     isIn(options: string | string[]): Validator;
-    /**
-     * Will work against Visa, MasterCard, American Express, Discover, Diners Club, and JCB card numbering formats
-     */
     isCreditCard(): Validator;
     isISIN(): Validator;
+    /**
+     * @param version
+     * @see https://en.wikipedia.org/wiki/International_Standard_Book_Number
+     */
     isISBN(version?: number): Validator;
+    /**
+     * @param options
+     * @see https://en.wikipedia.org/wiki/International_Standard_Serial_Number
+     */
     isISSN(options?: ExpressValidator.Options.IsISSNOptions): Validator
     isMobilePhone(locale: string): Validator; // TODO MobilePhoneLocale
     isCurrency(options: ExpressValidator.Options.IsCurrencyOptions): Validator;
+    /**
+     * @see https://en.wikipedia.org/wiki/ISO_8601
+     */
     isISO8601(): Validator;
+    /**
+     * @see https://en.wikipedia.org/wiki/Base64
+     */
     isBase64(): Validator;
+    /**
+     * @see https://en.wikipedia.org/wiki/Data_URI_scheme
+     */
     isDataURI(): Validator;
     isWhitelisted(chars: string | string[]): Validator;
 
@@ -186,17 +190,14 @@ declare namespace ExpressValidator {
 
     equals(equals: any): Validator;
     contains(str: string): Validator;
-    /**
-     * Usage: matches(/[a-z]/i) or matches('[a-z]','i')
-     */
-    matches(str: string, pattern: RegExp | string, modifiers?: string): Validator;
+    matches(pattern: RegExp | string, modifiers?: string): Validator;
 
 
     // Additional ValidatorChain.prototype.* validators
 
     notEmpty(): Validator;
     len(options: ExpressValidator.Options.MinMaxOptions): Validator;
-    optional(options?: { checkFalsy?: boolean }): Validator;
+    optional(options?: ExpressValidator.Options.OptionalOptions): Validator;
     withMessage(message: string): Validator;
   }
 
@@ -205,18 +206,32 @@ declare namespace ExpressValidator {
      * Convert the input string to a date, or null if the input is not a date.
      */
     toDate(): Sanitizer;
+    /**
+     * Convert the input string to a float, or NaN if the input is not a float.
+     */
     toFloat(): Sanitizer;
+    /**
+     * Convert the input string to a float, or NaN if the input is not a float.
+     */
     toInt(radix?: number): Sanitizer;
     /**
-     * True unless str = '0', 'false', or str.length == 0. In strict mode only '1' and 'true' return true.
+     * Cnvert the input string to a boolean.
+     * Everything except for '0', 'false' and '' returns true.
+     * @param strict If true, only '1' and 'true' return true.
      */
     toBoolean(strict?: boolean): Sanitizer;
     /**
-     * Trim optional `chars`, default is to trim whitespace (\r\n\t )
+     * Trim characters (whitespace by default) from both sides of the input.
+     * @param chars Defaults to whitespace
      */
     trim(chars: string): Sanitizer;
     ltrim(chars: string): Sanitizer;
     rtrim(chars: string): Sanitizer;
+    /**
+     * Remove characters with a numerical value < 32 and 127, mostly control characters.
+     * Unicode-safe in JavaScript.
+     * @param keep_new_lines If true, newline characters are preserved (\n and \r, hex 0xA and 0xD).
+     */
     stripLow(keep_new_lines?: boolean): Sanitizer;
     /**
      * Escape &, <, >, and "
@@ -263,12 +278,36 @@ declare namespace ExpressValidator.Options {
     allow_leading_zeroes: boolean;
   }
 
+  /**
+   * defaults to
+   * {
+   *    allow_display_name: false,
+   *    require_display_name: false,
+   *    allow_utf8_local_part: true,
+   *    require_tld: true
+   * }
+   */
   interface IsEmailOptions {
     allow_display_name?: boolean;
     allow_utf8_local_part?: boolean;
     require_tld?: boolean;
   }
 
+  /**
+   * defaults to
+   * {
+   *    protocols: ['http','https','ftp'],
+   *    require_tld: true,
+   *    require_protocol: false,
+   *    require_host: true,
+   *    require_valid_protocol: true,
+   *    allow_underscores: false,
+   *    host_whitelist: false,
+   *    host_blacklist: false,
+   *    allow_trailing_dot: false,
+   *    allow_protocol_relative_urls: false
+   * }
+   */
   interface IsURLOptions {
     protocols?: string[];
     require_tld?: boolean;
@@ -282,17 +321,49 @@ declare namespace ExpressValidator.Options {
     allow_protocol_relative_urls?: boolean;
   }
 
+  /**
+   * defaults to
+   * {
+   *    require_tld: true,
+   *    allow_underscores: false,
+   *    allow_trailing_dot: false
+   * }
+   */
   interface IsFQDNOptions {
     require_tld?: boolean;
     allow_underscores?: boolean;
     allow_trailing_dot?: boolean;
   }
 
+  /**
+   * defaults to
+   * {
+   *    case_sensitive: false,
+   *    require_hyphen: false
+   * }
+   */
   interface IsISSNOptions {
     case_sensitive: boolean
     require_hyphen: boolean
   }
 
+  /**
+   * defaults to
+   * {
+   *   symbol: '$',
+   *   require_symbol: false,
+   *   allow_space_after_symbol: false,
+   *   symbol_after_digits: false,
+   *   allow_negatives: true,
+   *   parens_for_negatives: false,
+   *   negative_sign_before_digits: false,
+   *   negative_sign_after_digits: false,
+   *   allow_negative_sign_placeholder: false,
+   *   thousands_separator: ',',
+   *   decimal_separator: '.',
+   *   allow_space_after_digits: false
+   * }
+   */
   interface IsCurrencyOptions {
     symbol?: string;
     require_symbol?: boolean;
@@ -308,9 +379,29 @@ declare namespace ExpressValidator.Options {
     allow_space_after_digits?: boolean;
   }
 
+  interface OptionalOptions {
+    checkFalsy?: boolean;
+  }
+
 
   // SANITIZERS
 
+  /**
+   * Defaults to
+   * {
+   *   all_lowercase: true
+   *   gmail_lowercase: true
+   *   gmail_remove_dots: true
+   *   gmail_remove_subaddress: true
+   *   gmail_convert_googlemaildotcom: true
+   *   outlookdotcom_lowercase: true
+   *   outlookdotcom_remove_subaddress: true
+   *   yahoo_lowercase: true
+   *   yahoo_remove_subaddress: true
+   *   icloud_lowercase: true
+   *   icloud_remove_subaddress: true
+   * }
+   */
   interface NormalizeEmailOptions {
     all_lowercase: boolean
     gmail_lowercase: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,243 @@
+// Type definitions for express-validator 3.0.0
+// Project: https://github.com/ctavan/express-validator
+// Definitions by: Nathan Ridley <https://github.com/axefrog/>, Jonathan Häberle <http://dreampulse.de>, Peter Harris <https://github.com/codeanimal/>, Ayman Nedjmeddine <https://github.com/IOAyman>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as express from 'express'
+import * as Promise from 'bluebird'
+
+// Add RequestValidation Interface on to Express's Request Interface.
+declare namespace Express {
+  interface Request extends ExpressValidator.RequestValidation {}
+}
+
+// External express-validator module.
+declare module "express-validator" {
+
+  /**
+   * @middlewareOptions see: https://github.com/ctavan/express-validator#middleware-options
+   */
+  function ExpressValidator(middlewareOptions?: any): express.RequestHandler;
+
+  export = ExpressValidator;
+}
+
+// Internal Module.
+declare namespace ExpressValidator {
+
+  export interface ValidationError {
+    msg: string;
+    param: string;
+  }
+
+  interface ValidatorFunction { (item: string | {}, message?: string): Validator; }
+  interface ValidatorExtraFunction extends ValidatorFunction { (matchIndex: number, message?: string): Validator; }
+  interface SanitizerFunction { (item: string): Sanitizer; }
+  interface Dictionary<T> { [key: string]: T; }
+
+  export interface RequestValidation {
+    assert: ValidatorExtraFunction;
+    validate: ValidatorExtraFunction;
+    check: ValidatorExtraFunction;
+    checkBody: ValidatorFunction;
+    checkFiles: ValidatorFunction;
+    checkHeaders: ValidatorFunction;
+    checkParams: ValidatorFunction;
+    checkQuery: ValidatorFunction;
+
+    filter: SanitizerFunction;
+    sanitize: SanitizerFunction;
+    sanitizeBody: SanitizerFunction;
+    sanitizeQuery: SanitizerFunction;
+    sanitizeParams: SanitizerFunction;
+    sanitizeHeaders: SanitizerFunction;
+
+    onValidationError(errback: (msg: string) => void): void;
+    validationErrors(mapped?: boolean): Dictionary<MappedError> | MappedError[];
+    validationErrors<T>(mapped?: boolean): Dictionary<T> | T[];
+    asyncValidationErrors(mapped?: boolean): Promise<MappedError[] | Dictionary<MappedError>>;
+    asyncValidationErrors<T>(mapped?: boolean): Promise<T[] | Dictionary<T>>;
+  }
+
+  export interface Validator {
+    /**
+     * Alias for regex()
+     */
+    is(): Validator;
+    /**
+     * Alias for notRegex()
+     */
+    not(): Validator;
+    isEmail(options?: {}): Validator;
+    /**
+     * Accepts http, https, ftp
+     */
+    isURL(): Validator;
+    isFQDN(options?: MinMaxOptions): Validator;
+
+    /**
+     * Combines isIPv4 and isIPv6
+     */
+    isIP(): Validator;
+    isIPv4(): Validator;
+    isIPv6(): Validator;
+    isMACAddress(): Validator;
+    isISBN(version?: number): Validator;
+    isISIN(): Validator;
+    isISO8601(): Validator;
+    isMobilePhone(locale: string): Validator;
+    isMongoId(): Validator;
+    isMultibyte(): Validator;
+    isAlpha(locale?: string): Validator;
+    isAlphanumeric(locale?: string): Validator;
+    isAscii(): Validator;
+    isBase64(): Validator;
+    isBoolean(): Validator;
+    isByteLength(options: MinMaxOptions): Validator;
+    isCurrency(options: {}): Validator;
+    isDataURI(): Validator;
+    isDivisibleBy(num: number): Validator;
+    isNumeric(): Validator;
+    isHexadecimal(): Validator;
+    /**
+     * Accepts valid hexcolors with or without # prefix
+     */
+    isHexColor(): Validator;
+    /**
+     * isNumeric accepts zero padded numbers, e.g. '001', isInt doesn't
+     */
+    isInt(options?: MinMaxOptions): Validator;
+    isLowercase(): Validator;
+    isUppercase(): Validator;
+    isDecimal(): Validator;
+    /**
+     * Alias for isDecimal
+     */
+    isFloat(): Validator;
+    isFullWidth(): Validator;
+    isHalfWidth(): Validator;
+    isVariableWidth(): Validator;
+    /**
+     * Check if length is 0
+     */
+    isNull(): Validator;
+    /**
+     * Not just whitespace (input.trim().length !== 0)
+     */
+    notEmpty(): Validator;
+    equals(equals: any): Validator;
+    contains(str: string): Validator;
+
+    /**
+     * Usage: matches(/[a-z]/i) or matches('[a-z]','i')
+     */
+    matches(pattern: string, modifiers?: string): Validator;
+    matches(pattern: RegExp): Validator;
+
+    /**
+     * max is optional
+     */
+    len(min: number, max?: number): Validator;
+    /**
+     * Version can be 3, 4 or 5 or empty, see http://en.wikipedia.org/wiki/Universally_unique_identifier
+     */
+    isUUID(version?: number): Validator;
+    /**
+     * Alias for isUUID(3)
+     */
+    isUUIDv3(): Validator;
+    /**
+     * Alias for isUUID(4)
+     */
+    isUUIDv4(): Validator;
+    /**
+     * Alias for isUUID(5)
+     */
+    isUUIDv5(): Validator;
+    /**
+     * Uses Date.parse() - regex is probably a better choice
+     */
+    isDate(): Validator;
+    /**
+     * Argument is optional and defaults to today. Comparison is non-inclusive
+     */
+    isAfter(date?: Date): Validator;
+    /**
+     * Argument is optional and defaults to today. Comparison is non-inclusive
+     */
+    isBefore(date?: Date): Validator;
+    isIn(options: string): Validator;
+    isIn(options: string[]): Validator;
+    notIn(options: string): Validator;
+    notIn(options: string[]): Validator;
+    max(val: string): Validator;
+    min(val: string): Validator;
+    isJSON(): Validator;
+    isLength(options: MinMaxOptions): Validator;
+    isWhitelisted(chars: string): Validator;
+    /**
+     * Will work against Visa, MasterCard, American Express, Discover, Diners Club, and JCB card numbering formats
+     */
+    isCreditCard(): Validator;
+    /**
+     * Check an input only when the input exists
+     */
+    isSurrogatePar(): Validator;
+
+    optional(options?: { checkFalsy?: boolean }): Validator;
+    withMessage(message: string): Validator;
+  }
+
+  interface Sanitizer {
+    /**
+     * Trim optional `chars`, default is to trim whitespace (\r\n\t )
+     */
+    trim(...chars: string[]): Sanitizer;
+    ltrim(...chars: string[]): Sanitizer;
+    rtrim(...chars: string[]): Sanitizer;
+    stripLow(keep_new_lines?: boolean): Sanitizer;
+    toFloat(): Sanitizer;
+    toInt(radix?: number): Sanitizer;
+    /**
+     * True unless str = '0', 'false', or str.length == 0. In strict mode only '1' and 'true' return true.
+     */
+    toBoolean(strict?: boolean): Sanitizer;
+
+    /**
+     * Convert the input string to a date, or null if the input is not a date.
+     */
+    toDate(): Sanitizer;
+
+    /**
+     * Escape &, <, >, and "
+     */
+    escape(): Sanitizer;
+
+    /**
+     * Replaces HTML encoded entities with <, >, &, ', " and /.
+     */
+    unescape(): Sanitizer;
+
+    blacklist(chars: string): Sanitizer;
+    blacklist(chars: string[]): Sanitizer;
+    whitelist(chars: string): Sanitizer;
+    whitelist(chars: string[]): Sanitizer;
+
+    normalizeEmail(options?: { lowercase?: boolean; remove_dots?: boolean; remove_extensions?: boolean }): Sanitizer;
+
+    /**
+     * !!! XSS sanitization was removed from the library (see: https://github.com/chriso/validator.js#xss-sanitization)
+     */
+  }
+
+  interface MappedError {
+    param: string;
+    msg: string;
+    value: string;
+  }
+
+  interface MinMaxOptions {
+    min?: number;
+    max?: number;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ declare namespace ExpressValidator {
 
   export type URLProtocol = 'http' | 'https' | 'ftp'
   export type UUIDVersion = 3 | 4 | 5 | 'all'
+  export type IPVersion = 4 | 6
   export type AlphaLocale = 'ar' | 'ar-AE' | 'ar-BH' | 'ar-DZ' | 'ar-EG' | 'ar-IQ' | 'ar-JO' | 'ar-KW' | 'ar-LB' | 'ar-LY' | 'ar-MA' | 'ar-QA' | 'ar-QM' | 'ar-SA' | 'ar-SD' | 'ar-SY' | 'ar-TN' | 'ar-YE' | 'cs-CZ' | 'da-DK' | 'de-DE' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fr-FR' | 'hu-HU' | 'nl-NL' | 'pl-PL' | 'pt-BR' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'sr-RS@latin' | 'tr-TR' | 'uk-UA'
   export type AlphanumericLocale = 'ar' | 'ar-AE' | 'ar-BH' | 'ar-DZ' | 'ar-EG' | 'ar-IQ' | 'ar-JO' | 'ar-KW' | 'ar-LB' | 'ar-LY' | 'ar-MA' | 'ar-QA' | 'ar-QM' | 'ar-SA' | 'ar-SD' | 'ar-SY' | 'ar-TN' | 'ar-YE' | 'cs-CZ' | 'da-DK' | 'de-DE' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fr-FR' | 'fr-BE' | 'hu-HU' | 'nl-BE' | 'nl-NL' | 'pl-PL' | 'pt-BR' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'sr-RS@latin' | 'tr-TR' | 'uk-UA'
   export type MobilePhoneLocal = 'ar-DZ' | 'ar-SA' | 'ar-SY' | 'cs-CZ' | 'de-DE' | 'da-DK' | 'el-GR' | 'en-AU' | 'en-GB' | 'en-HK' | 'en-IN' | 'en-NZ' | 'en-US' | 'en-CA' | 'en-ZA' | 'en-ZM' | 'es-ES' | 'fi-FI' | 'fr-FR' | 'hu-HU' | 'it-IT' | 'ja-JP' | 'ms-MY' | 'nb-NO' | 'nn-NO' | 'pl-PL' | 'pt-PT' | 'ru-RU' | 'sr-RS' | 'tr-TR' | 'vi-VN' | 'zh-CN' | 'zh-TW'
@@ -144,10 +145,16 @@ declare namespace ExpressValidator {
      *
      * @param version IP version number 4 or 6
      */
-    isIP(version?: number): Validator;
+    isIP(version?: IPVersion): Validator;
     isFQDN(options?: ExpressValidator.Options.IsFQDNOptions): Validator;
     isBoolean(): Validator;
+    /**
+     * @param locale Optional. Defaults to en-US
+     */
     isAlpha(locale?: AlphaLocale): Validator;
+    /**
+     * @param locale Optional. Defaults to en-US
+     */
     isAlphanumeric(locale?: AlphanumericLocale): Validator;
     isNumeric(): Validator;
     isLowercase(): Validator;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,7 @@
 // Type definitions for express-validator 3.0.0
 // Project: https://github.com/ctavan/express-validator
-// Definitions by: Nathan Ridley <https://github.com/axefrog/>, Jonathan Häberle <http://dreampulse.de>, Peter Harris <https://github.com/codeanimal/>, Ayman Nedjmeddine <https://github.com/IOAyman>
+// Definitions by: Ayman Nedjmeddine <https://github.com/IOAyman>, Nathan Ridley <https://github.com/axefrog/>, Jonathan Häberle <http://dreampulse.de>, Peter Harris <https://github.com/codeanimal/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 import * as express from 'express'
 import * as Promise from 'bluebird'
 
@@ -17,7 +16,7 @@ declare module "express-validator" {
   /**
    * @middlewareOptions see: https://github.com/ctavan/express-validator#middleware-options
    */
-  function ExpressValidator(middlewareOptions?: any): express.RequestHandler;
+  function ExpressValidator(options?: ExpressValidator.ExpressValidatorOptions): express.RequestHandler;
 
   export = ExpressValidator;
 }
@@ -25,15 +24,17 @@ declare module "express-validator" {
 // Internal Module.
 declare namespace ExpressValidator {
 
-  export interface ValidationError {
-    msg: string;
-    param: string;
-  }
-
   interface ValidatorFunction { (item: string | {}, message?: string): Validator; }
   interface ValidatorExtraFunction extends ValidatorFunction { (matchIndex: number, message?: string): Validator; }
   interface SanitizerFunction { (item: string): Sanitizer; }
   interface Dictionary<T> { [key: string]: T; }
+  interface Result {
+    isEmpty(): boolean
+    array(): MappedError[]
+    mapped(): Dictionary<MappedError>
+    useFirstErrorOnly(): Result
+    throw(): Result
+  }
 
   export interface RequestValidation {
     assert: ValidatorExtraFunction;
@@ -52,11 +53,9 @@ declare namespace ExpressValidator {
     sanitizeParams: SanitizerFunction;
     sanitizeHeaders: SanitizerFunction;
 
-    onValidationError(errback: (msg: string) => void): void;
-    validationErrors(mapped?: boolean): Dictionary<MappedError> | MappedError[];
-    validationErrors<T>(mapped?: boolean): Dictionary<T> | T[];
     asyncValidationErrors(mapped?: boolean): Promise<MappedError[] | Dictionary<MappedError>>;
     asyncValidationErrors<T>(mapped?: boolean): Promise<T[] | Dictionary<T>>;
+    getValidationResult(): Promise<Result>
   }
 
   export interface Validator {
@@ -239,5 +238,11 @@ declare namespace ExpressValidator {
   interface MinMaxOptions {
     min?: number;
     max?: number;
+  }
+
+  export interface ExpressValidatorOptions {
+    customValidators: { [validatorName: string]: (value: any) => boolean }
+    customSanitizers: { [sanitizername: string]: (value: any) => any }
+    errorFormatter: (param: string, msg: string, value: any) => {param: string, msg: string, value: any}
   }
 }

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -46,7 +46,7 @@ validator.init();
 
 // validators and sanitizers not prefixed with is/to
 var additionalValidators = ['contains', 'equals', 'matches'];
-var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'stripLow', 'whitelist', 'blacklist', 'normalizeEmail'];
+var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'unescape', 'stripLow', 'whitelist', 'blacklist', 'normalizeEmail'];
 
 /**
  * Initializes a chain of validators

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -77,7 +77,7 @@ function ValidatorChain(param, failMsg, req, location, options) {
  * @class
  * @param  {(string|string[])}  param    path to property to sanitize
  * @param  {[type]}             req             request to sanitize
- * @param  {[type]}             location        request property to find value
+ * @param  {[string]}           locations        request property to find value
  */
 
 function Sanitizer(param, req, locations) {
@@ -376,7 +376,7 @@ var expressValidator = function(options) {
  * @method validateSchema
  * @param  {Object}       schema    schema of validations
  * @param  {Request}      req       request to attach validation errors
- * @param  {string}       location  request property to find value (body, params, query, etc.)
+ * @param  {string}       loc  request property to find value (body, params, query, etc.)
  * @param  {Object}       options   options containing custom validators & errorFormatter
  * @return {object[]}               array of errors
  */

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "@orfaust",
     "@zero21xxx",
     "Roman Kalyakin <roman@kalyakin.com>",
-    "Rusty Bailey <rustylbailey@gmail.com>"
+    "Rusty Bailey <rustylbailey@gmail.com>",
+    "Gustavo Henke <guhenke@gmail.com>",
+    "Ayman Nedjmeddine <theycallmethedr@gmail.com>"
   ],
   "version": "3.0.0",
   "homepage": "https://github.com/ctavan/express-validator",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "@types/bluebird": "~3.0.36",
+    "@types/express": "~4.0.34",
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",
+    "typescript": "~2.0.10",
     "validator": "~6.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,13 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "@types/bluebird": "~3.0.36",
-    "@types/express": "~4.0.34",
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",
-    "typescript": "~2.0.10",
     "validator": "~6.2.0"
   },
   "devDependencies": {
+    "@types/bluebird": "~3.0.36",
+    "@types/express": "~4.0.34",
     "body-parser": "1.12.3",
     "cookie-parser": "1.4.1",
     "chai": "2.3.0",
@@ -48,7 +47,8 @@
     "jshint": "2.7.0",
     "mocha": "2.2.4",
     "nyc": "8.4.0",
-    "supertest": "0.15.0"
+    "supertest": "0.15.0",
+    "typescript": "~2.0.10"
   },
   "keywords": [
     "express",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",
-    "validator": "~6.1.0"
+    "validator": "~6.2.0"
   },
   "devDependencies": {
     "body-parser": "1.12.3",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "url": "git://github.com/ctavan/express-validator.git"
   },
   "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
-    "test": "nyc mocha",
+    "test": "nyc mocha && tsc",
     "jshint": "jshint ./test ./lib",
     "jscs": "jscs ./test ./lib",
     "travis-build": "npm test && npm run jshint && npm run jscs",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "@types/bluebird": "~3.0.36",
+    "@types/express": "~4.0.34",
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",
     "validator": "~6.2.0"
   },
   "devDependencies": {
-    "@types/bluebird": "~3.0.36",
-    "@types/express": "~4.0.34",
     "body-parser": "1.12.3",
     "cookie-parser": "1.4.1",
     "chai": "2.3.0",

--- a/test/typeDefinitionTest.ts
+++ b/test/typeDefinitionTest.ts
@@ -49,7 +49,13 @@ app.use((req: express.Request, res: express.Response, next: express.NextFunction
 
   // VALIDATIONS
 
-  const schema = { param: { in: 'headers' } };
+  const schema: ExpressValidator.ValidationSchema = {
+    param: {
+      in: 'headers',
+      contains: { errorMessage: 'message', options: [] },
+      isAwesomeLib: { errorMessage: 'message', options: [] }
+    }
+  };
 
   req.assert('param').isEmail({ require_tld: true });
   req.assert('param', 'message');

--- a/test/typeDefinitionTest.ts
+++ b/test/typeDefinitionTest.ts
@@ -1,0 +1,136 @@
+import * as validator from '../lib/express_validator'
+import * as express from 'express'
+const app = express();
+
+
+app.use(validator({
+  customValidators: { isAwesomeLib: (value: any) => isNaN(value) ? true : true },
+  customSanitizers: { toAwesome: (lib: any) => [lib] },
+  errorFormatter: (param: string, msg: string, value: any) => ({ param, msg, value })
+}));
+
+app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.setHeader('Content-Type', 'application/json');
+
+
+  // SANITIZERS
+
+  req.sanitizeCookies('param');
+  req.sanitizeHeaders('param');
+  req.sanitizeParams('param');
+  req.sanitizeQuery('param');
+  req.sanitizeBody('param');
+  req.sanitize('param');
+  req.filter('param')
+    .toDate()
+    .toFloat()
+    .toInt().toInt(10)
+    .toBoolean().toBoolean(true)
+    .trim('')
+    .ltrim('').rtrim('')
+    .stripLow().stripLow(true)
+    .escape().unescape()
+    .blacklist('').whitelist('')
+    .normalizeEmail()
+    .normalizeEmail({
+      all_lowercase: true,
+      gmail_lowercase: true,
+      gmail_remove_dots: true,
+      gmail_remove_subaddress: true,
+      gmail_convert_googlemaildotcom: true,
+      outlookdotcom_lowercase: true,
+      outlookdotcom_remove_subaddress: true,
+      yahoo_lowercase: true,
+      yahoo_remove_subaddress: true,
+      icloud_lowercase: true,
+      icloud_remove_subaddress: true
+    });
+
+
+  // VALIDATIONS
+
+  const schema = { param: { in: 'headers' } };
+
+  req.assert('param').isEmail({ require_tld: true });
+  req.assert('param', 'message');
+  req.assert('param.child', 'message').optional();
+  req.assert(schema);
+
+  req.validate('param');
+  req.validate('param', 'message');
+  req.validate('param.child', 'message').optional();
+  req.validate(schema);
+
+  req.check('param').isEmail({ require_tld: true });
+  req.check('param', 'message');
+  req.check('param.child', 'message');
+  req.check(['param', 'child'], 'message').optional();
+  req.check(schema);
+
+
+  req.checkBody('param').isEmail({ require_tld: true });
+  req.checkBody('param', 'message');
+  req.checkBody('param.child', 'message');
+  req.checkBody(['param', 'child'], 'message').optional();
+  req.checkBody(schema);
+
+
+  req.checkCookies('param').isEmail({ require_tld: true });
+  req.checkCookies('param', 'message');
+  req.checkCookies('param.child', 'message');
+  req.checkCookies(['param', 'child'], 'message').optional();
+  req.checkCookies(schema);
+
+
+  req.checkHeaders('param').isEmail({ require_tld: true });
+  req.checkHeaders('param', 'message');
+  req.checkHeaders('param.child', 'message');
+  req.checkHeaders(['param', 'child'], 'message').optional();
+  req.checkHeaders(schema);
+
+
+  req.checkParams('param').isEmail({ require_tld: true });
+  req.checkParams('param', 'message');
+  req.checkParams('param.child', 'message');
+  req.checkParams(['param', 'child'], 'message').optional();
+  req.checkParams(schema);
+
+
+  req.checkQuery('param').isEmail({ require_tld: true });
+  req.checkQuery('param', 'message');
+  req.checkQuery('param.child', 'message');
+  req.checkQuery(['param', 'child'], 'message').optional();
+  req.checkQuery(schema);
+
+
+  // TODO chain all validators
+
+
+  req.getValidationResult()
+
+    .then(result => result.isEmpty() ? next() : result.throw())
+
+    .catch(result =>
+      next({
+        mapped: result.mapped(),
+        array: result.array(),
+        first_only: {
+          mapped: result.mapped(),
+          array: result.array()
+        }
+      }));
+
+
+  // deprecated but still available
+
+  req.asyncValidationErrors()
+    .then(() => next())
+    .catch(errors => next(errors));
+
+  let errors: any;
+  errors = req.validationErrors();
+  errors = req.validationErrors(true);
+  if (errors)
+    return next(errors)
+
+});

--- a/test/typeDefinitionTest.ts
+++ b/test/typeDefinitionTest.ts
@@ -109,8 +109,87 @@ app.use((req: express.Request, res: express.Response, next: express.NextFunction
   req.checkQuery(schema);
 
 
-  // TODO chain all validators
+  req.check('param', 'message')
+    .isEmail().isEmail({ allow_display_name: true, allow_utf8_local_part: true, require_tld: true })
+    .isURL({
+      protocols: ['http', 'https', 'ftp'],
+      require_tld: true,
+      require_protocol: true,
+      require_host: true,
+      require_valid_protocol: true,
+      allow_underscores: true,
+      host_whitelist: ['', / /i],
+      host_blacklist: ['', / /i],
+      allow_trailing_dot: true,
+      allow_protocol_relative_urls: true,
+    })
+    .isMACAddress()
+    .isIP().isIP(4).isIP(6)
+    .isFQDN()
+    .isFQDN({ require_tld: true, allow_underscores: true, allow_trailing_dot: true })
+    .isBoolean()
+    .isAlpha().isAlpha('ar-DZ')
+    .isAlphanumeric().isAlphanumeric('ar-DZ')
+    .isNumeric()
+    .isLowercase()
+    .isUppercase()
+    .isAscii()
+    .isFullWidth()
+    .isHalfWidth()
+    .isVariableWidth()
+    .isMultibyte()
+    .isSurrogatePair()
+    .isInt().isInt({ min: 0, max: 0, lt: 0, gt: 0, allow_leading_zeroes: true })
+    .isFloat().isFloat({ min: 0, max: 0, lt: 0, gt: 0 })
+    .isDecimal()
+    .isHexadecimal()
+    .isDivisibleBy(0)
+    .isHexColor()
+    .isMD5()
+    .isJSON()
+    .isEmpty()
+    .isLength({ min: 0, max: 0 })
+    .isByteLength({ min: 0, max: 0 })
+    .isUUID().isUUID('all').isUUID(3).isUUID(4).isUUID(5)
+    .isMongoId()
+    .isDate()
+    .isAfter().isAfter(new Date())
+    .isBefore().isBefore(new Date())
+    .isIn([''])
+    .isCreditCard()
+    .isISIN()
+    .isISBN().isISBN(0)
+    .isISSN({ case_sensitive: true, require_hyphen: true })
+    .isMobilePhone('en-US')
+    .isCurrency({
+      symbol: '',
+      require_symbol: true,
+      allow_space_after_symbol: true,
+      symbol_after_digits: true,
+      allow_negatives: true,
+      parens_for_negatives: true,
+      negative_sign_before_digits: true,
+      negative_sign_after_digits: true,
+      allow_negative_sign_placeholder: true,
+      thousands_separator: '',
+      decimal_separator: '',
+      allow_space_after_digits: true
+    })
+    .isISO8601()
+    .isBase64()
+    .isDataURI()
+    .isWhitelisted('')
+    .isWhitelisted([''])
+    .equals(true).equals(0).equals('').equals({}).contains('')
+    .matches('').matches('', '').matches(/ /, '')
+    .notEmpty()
+    .len({ min: 0, max: 0 })
+    .optional().optional({ checkFalsy: true })
+    .withMessage('message');
 
+
+
+  // getting result
 
   req.getValidationResult()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es6",
+    "charset": "utf-8",
+    "pretty": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "outDir": "./build"
+  },
+  "exclude": [ "node_modules", "coverage" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "strictNullChecks": true,
     "outDir": "./build"
   },
+  "files": [ "index.d.ts" ],
   "exclude": [ "node_modules", "coverage" ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "strictNullChecks": true,
     "outDir": "./build"
   },
-  "files": [ "index.d.ts" ],
+  "files": [ "index.d.ts", "./test/typeDefinitionTest.ts" ],
   "exclude": [ "node_modules", "coverage" ]
 }


### PR DESCRIPTION
# Summery
Mainly, I have added the TypeScript type definitions for this library (based on the definitions at [DefinitelyTyped/express-validator](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e2af6d0/express-validator/express-validator.d.ts), which are out-dated and incomplete).

I am submitting this PR here because:
- The definitions would be included with the library itself, no need to install an extra package, for instance `@types/express-validator`.
- The process of merging fixes over at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) is slow and my take a while.

_PS: I will also submit the same update to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped)._


### Other minor changes:
- Upgraded validator.js to [v6.2.0](https://github.com/chriso/validator.js/blob/6.2.0/CHANGELOG.md).
- Added missing `unescape` sanitizer.
- Updated some JSDoc.