### PR TITLE
Moved necessary dependencies back to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "@types/bluebird": "~3.0.36",
+    "@types/express": "~4.0.34",
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",
     "validator": "~6.2.0"
   },
   "devDependencies": {
-    "@types/bluebird": "~3.0.36",
-    "@types/express": "~4.0.34",
     "body-parser": "1.12.3",
     "cookie-parser": "1.4.1",
     "chai": "2.3.0",


### PR DESCRIPTION
This is a fix for [`fd2631f`](https://github.com/ctavan/express-validator/commit/fd2631f#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R40); Those dependencies are required by the library's type definitions.
@gustavohenke, must have [missed](https://github.com/ctavan/express-validator/pull/289/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R35) them when you squashed that PR :)