### PR TITLE
Added check for missing validation method

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -441,6 +441,10 @@ function validateSchema(schema, req, loc, options) {
       if (opts != null && !Array.isArray(opts)) {
         opts = [opts];
       }
+      
+      if ('function' !== typeof validator[methodName]) {
+        throw new Error('Unknown validation method: "' + methodName + '" used for parameter: "' + param + '"');
+      }
 
       validator[methodName].apply(validator, opts);
     }


### PR DESCRIPTION
Added check for missing validation method, when validating schema object. This will throw user-friendly error instead of cryptic one: `TypeError: Cannot read property 'apply' of undefined`.