### PR TITLE
Add default export in type definitions to support ES6 import syntax.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module "express-validator" {
    */
   function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;
 
-  export = ExpressValidator;
+  export default ExpressValidator;
 }
 
 // Internal Module.


### PR DESCRIPTION
By changing "export = ExpressValidator" to "export default ExpressValidator", the module can be imported using ES6 syntax:

Instead of forcing users to use `import expressValidator = require('express-validator');`, they can now use `import expressValidator from 'express-validator';`.

I ran into this issue initially when trying to move to all ES6 syntax. It also led me to https://github.com/DefinitelyTyped/DefinitelyTyped/issues/10742 which seems to suggest that ES6 syntax isn't supported. 