### PR TITLE
#nullable()

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -159,6 +159,14 @@ var expressValidator = function(options) {
     return this;
   };
 
+  ValidatorChain.prototype.nullable = function() {
+    if (this.value === null) {
+      this.skipValidating = true;
+    }
+
+    return this;
+  };
+
   ValidatorChain.prototype.withMessage = function(message) {
     if (this.lastError) {
       if (this.lastError.isAsync) {
@@ -413,6 +421,15 @@ function validateSchema(schema, req, loc, options) {
 
       if (validator.skipValidating) {
         validator.failMsg = schema[param].optional.errorMessage || paramErrorMessage || 'Invalid param';
+        continue; // continue with the next param in schema
+      }
+    }
+
+    if (schema[param].nullable) {
+      validator.nullable();
+
+      if (validator.skipValidating) {
+        validator.failMsg = schema[param].nullable.errorMessage || paramErrorMessage || 'Invalid param';
         continue; // continue with the next param in schema
       }
     }

--- a/test/nullableSchemaTest.js
+++ b/test/nullableSchemaTest.js
@@ -1,0 +1,157 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not an integer';
+
+function validation(req, res) {
+  req.assert({
+    'nullable_param': {
+      isInt: {
+        errorMessage: errorMessage
+      },
+      nullable: true
+    }
+  });
+  req.assert({
+    'optional_nullable_param': {
+      isInt: {
+        errorMessage: errorMessage
+      },
+      optional: true,
+      nullable: true
+    }
+  });
+  req.assert({
+    'nullable_optional_param': {
+      isInt: {
+        errorMessage: errorMessage
+      },
+      nullable: true,
+      optional: true
+    }
+  });
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({ result: 'OK' });
+}
+
+function fail(body) {
+  expect(body).to.have.length(1);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('result', 'OK');
+}
+
+function testQuery(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function testBody(body, test, done) {
+  request(app)
+    .post('/path')
+    .send(body)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#nullableSchema()', function() {
+
+  describe('with #optionalSchema()', function() {
+    it('should return a success when optional params are not provided', function(done) {
+      testBody({ nullable_param: null }, pass, done);
+    });
+    it('should return a success when #optional() called before #nullable()', function(done) {
+      testBody({ nullable_param: null, optional_nullable_param: null }, pass, done);
+    });
+    it('should return a success when #optional() called after #nullable()', function(done) {
+      testBody({ nullable_param: null, nullable_optional_param: null }, pass, done);
+    });
+  });
+
+  describe('query', function() {
+    it('should return an error when there is an empty route', function(done) {
+      testQuery('/', fail, done);
+    });
+
+    it('should return an error when there are no params on a route', function(done) {
+      testQuery('/path', fail, done);
+    });
+
+    it('should return an error when the non-nullable param is present', function(done) {
+      testQuery('/path?other_param=test', fail, done);
+    });
+
+    it('should return an error when param is provided, but empty', function(done) {
+      testQuery('/path?nullable_param', fail, done);
+    });
+
+    it('should return an error when param is provided with equals sign, but empty', function(done) {
+      testQuery('/path?nullable_param=', fail, done);
+    });
+
+    it('should return an error when param is provided, but fails validation', function(done) {
+      testQuery('/path?nullable_param=test', fail, done);
+    });
+
+    it('should return a success when param is provided and validated', function(done) {
+      testQuery('/path?nullable_param=123', pass, done);
+    });
+
+    it('should return an error when param is "null"', function(done) {
+      // there is no way to receive null in query
+      testQuery('/path?nullable_param=null', fail, done);
+    });
+  });
+
+  describe('body', function() {
+    it('should return an error when body in null', function(done) {
+      testBody(null, fail, done);
+    });
+
+    it('should return an error when there is an empty body', function(done) {
+      testBody({}, fail, done);
+    });
+
+    it('should return an error when the non-nullable param is present', function(done) {
+      testBody({ other_param: 'test' }, fail, done);
+    });
+
+    it('should return an error when param is provided, but undefined', function(done) {
+      testBody({ nullable_param: undefined }, fail, done);
+    });
+
+    it('should return an error when param is provided, but fails validation', function(done) {
+      testBody({ nullable_param: 'test' }, fail, done);
+    });
+
+    it('should return a success when param is provided and validated', function(done) {
+      testBody({ nullable_param: 123 }, pass, done);
+    });
+
+    it('should return a success when param is null', function(done) {
+      testBody({ nullable_param: null }, pass, done);
+    });
+  });
+
+});

--- a/test/nullableTest.js
+++ b/test/nullableTest.js
@@ -1,0 +1,134 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+var errorMessage = 'Parameter is not an integer';
+
+function validation(req, res) {
+  req.assert('nullable_param', errorMessage).nullable().isInt();
+  req.assert('optional_nullable_param', errorMessage).optional().nullable().isInt();
+  req.assert('nullable_optional_param', errorMessage).nullable().optional().isInt();
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send({ result: 'OK' });
+}
+
+function fail(body) {
+  expect(body).to.have.length(1);
+  expect(body[0]).to.have.property('msg', errorMessage);
+}
+
+function pass(body) {
+  expect(body).to.have.property('result', 'OK');
+}
+
+function testQuery(path, test, done) {
+  request(app)
+    .get(path)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+function testBody(body, test, done) {
+  request(app)
+    .post('/path')
+    .send(body)
+    .end(function(err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function() {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('#nullable()', function() {
+
+  describe('with #optional()', function() {
+    it('should return a success when optional params are not provided', function(done) {
+      testBody({ nullable_param: null }, pass, done);
+    });
+    it('should return a success when #optional() called before #nullable()', function(done) {
+      testBody({ nullable_param: null, optional_nullable_param: null }, pass, done);
+    });
+    it('should return a success when #optional() called after #nullable()', function(done) {
+      testBody({ nullable_param: null, nullable_optional_param: null }, pass, done);
+    });
+  });
+
+  describe('query', function() {
+    it('should return an error when there is an empty route', function(done) {
+      testQuery('/', fail, done);
+    });
+
+    it('should return an error when there are no params on a route', function(done) {
+      testQuery('/path', fail, done);
+    });
+
+    it('should return an error when the non-nullable param is present', function(done) {
+      testQuery('/path?other_param=test', fail, done);
+    });
+
+    it('should return an error when param is provided, but empty', function(done) {
+      testQuery('/path?nullable_param', fail, done);
+    });
+
+    it('should return an error when param is provided with equals sign, but empty', function(done) {
+      testQuery('/path?nullable_param=', fail, done);
+    });
+
+    it('should return an error when param is provided, but fails validation', function(done) {
+      testQuery('/path?nullable_param=test', fail, done);
+    });
+
+    it('should return a success when param is provided and validated', function(done) {
+      testQuery('/path?nullable_param=123', pass, done);
+    });
+
+    it('should return an error when param is "null"', function(done) {
+      // there is no way to receive null in query
+      testQuery('/path?nullable_param=null', fail, done);
+    });
+  });
+
+  describe('body', function() {
+    it('should return an error when body in null', function(done) {
+      testBody(null, fail, done);
+    });
+
+    it('should return an error when there is an empty body', function(done) {
+      testBody({}, fail, done);
+    });
+
+    it('should return an error when the non-nullable param is present', function(done) {
+      testBody({ other_param: 'test' }, fail, done);
+    });
+
+    it('should return an error when param is provided, but undefined', function(done) {
+      testBody({ nullable_param: undefined }, fail, done);
+    });
+
+    it('should return an error when param is provided, but fails validation', function(done) {
+      testBody({ nullable_param: 'test' }, fail, done);
+    });
+
+    it('should return a success when param is provided and validated', function(done) {
+      testBody({ nullable_param: 123 }, pass, done);
+    });
+
+    it('should return a success when param is null', function(done) {
+      testBody({ nullable_param: null }, pass, done);
+    });
+  });
+
+});


### PR DESCRIPTION
Use the nullable() method to allow null values.

```javascript
req.checkBody('price').nullable().isDecimal();
// if there is no error, req.body.price is either null or a valid decimal.
```

or even

```javascript
req.checkBody('price').optional().nullable().isDecimal();
// if there is no error, req.body.price is either undefined or null or a valid decimal.
```

Before it was like this
```javascript
if (req.body.price !== null) {
  req.checkBody('price').optional().isDecimal();
}
```