### PR TITLE
WIP: Alternate wildcard validation implementation.

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -61,15 +61,73 @@ var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'unescape', 'str
 
 function ValidatorChain(param, failMsg, req, location, options) {
   this.errorFormatter = options.errorFormatter;
-  this.param = param;
-  this.value = location ? _.get(req[location], param) : undefined;
   this.validationErrors = [];
   this.failMsg = failMsg;
   this.req = req;
   this.lastError = null; // used by withMessage to get the values of the last error
+
+  // array of (path, value) pairs to be validated
+  this.items = [];
+
+  // split path by wildcard segments
+  // e.g. 'users.*.emails' => [users, emails]
+  param = _.isArray(param) ? param.join('.') : param.toString();
+  var pathSegments = param
+    .split('*')
+    .map(function (pathSegment) {
+      return _.trim(pathSegment, '.');
+    });
+
+  // populate the 'items' array via bredth-first search of properties
+  traverseParams(req[location], null, pathSegments, 0, this.items);
+
   return this;
 }
 
+function traverseParams(object, prevPath, pathSegments, depth, items) {
+  // construct sub-param for current depth
+  var currentParamSegment = pathSegments[depth];
+  var param = [prevPath, currentParamSegment]
+    .filter(function (value) {
+      return !_.isEmpty(value);
+    })
+    .join('.');
+
+  // max depth of traversal reached, return
+  if (depth === pathSegments.length - 1) {
+    items.push({
+      param: param,
+      value: _.get(object, param)
+    });
+    return;
+  }
+
+  // empty node reached, return
+  var node = _.get(object, param);
+  var keys = node ? _.keys(node) : null;
+  if (_.isNil(node) || keys.length === 0) {
+    items.push({
+      param: constructPath(param, pathSegments, depth),
+      value: undefined
+    });
+    return;
+  }
+
+  // traverse properties deeper
+  keys.forEach(function (key) {
+    traverseParams(object, param + '.' + key, pathSegments, depth + 1, items);
+  });
+}
+
+function constructPath(prevPath, pathSegments, depth) {
+
+  var preparedPathSegments = pathSegments
+    .slice(depth)
+    .map(function (pathSegment) {
+      return pathSegment === '' ? '*' : pathSegment;
+    });
+  return preparedPathSegments.join('.');
+}
 
 /**
  * Initializes a sanitizer
@@ -147,13 +205,21 @@ var expressValidator = function(options) {
     var options = _.assign(defaults, opts);
 
     if (options.checkFalsy) {
-      if (!this.value) {
-        this.skipValidating = true;
-      }
+      this.items = this.items.map(function (item) {
+        if (!item.value) {
+          item.skipValidating = true;
+        }
+
+        return item;
+      });
     } else {
-      if (this.value === undefined) {
-        this.skipValidating = true;
-      }
+      this.items = this.items.map(function (item) {
+        if (item.value === undefined) {
+          item.skipValidating = true;
+        }
+
+        return item;
+      });
     }
 
     return this;
@@ -458,42 +524,45 @@ function validateSchema(schema, req, loc, options) {
 
 function makeValidator(methodName, container) {
   return function() {
-    if (this.skipValidating) {
-      return this;
-    }
+    var options = Array.prototype.slice.call(arguments);
+    var validator = this;
+    validator.items.forEach(function (item) {
+      if (item.skipValidating) {
+        return this;
+      }
+      var args = [];
+      args.push(item.value);
+      args = args.concat(options);
 
-    var args = [];
-    args.push(this.value);
-    args = args.concat(Array.prototype.slice.call(arguments));
+      var isValid = container[methodName].apply(container, args);
 
-    var isValid = container[methodName].apply(container, args);
+        // Perform string replacement in the error message
+      var msg = validator.failMsg;
+      if (typeof msg === 'string') {
+        args.forEach(function(arg, i) { msg = msg.replace('%' + i, arg); });
+      }
+      var error = formatErrors.call(validator, item.param, msg || 'Invalid value', item.value);
 
-    // Perform string replacement in the error message
-    var msg = this.failMsg;
-    if (typeof msg === 'string') {
-      args.forEach(function(arg, i) { msg = msg.replace('%' + i, arg); });
-    }
-    var error = formatErrors.call(this, this.param, msg || 'Invalid value', this.value);
-
-    if (isValid.then) {
-      var promise = isValid.catch(function() {
-        return Promise.reject(error);
-      });
-      this.lastError = {
-        promise: isValid,
-        param: this.param,
-        value: this.value,
-        context: this,
-        isAsync: true
-      };
-      this.req._asyncValidationErrors.push(promise);
-    } else if (!isValid) {
-      this.validationErrors.push(error);
-      this.req._validationErrors.push(error);
-      this.lastError = { param: this.param, value: this.value, isAsync: false };
-    } else {
-      this.lastError = null;
-    }
+      if (isValid.then) {
+        var promise = isValid.catch(function() {
+          return Promise.reject(error);
+        });
+        validator.lastError = {
+          promise: isValid,
+          param: item.param,
+          value: item.value,
+          context: validator,
+          isAsync: true
+        };
+        validator.req._asyncValidationErrors.push(promise);
+      } else if (!isValid) {
+        validator.validationErrors.push(error);
+        validator.req._validationErrors.push(error);
+        validator.lastError = { param: item.param, value: item.value, isAsync: false };
+      } else {
+        validator.lastError = null;
+      }
+    });
 
     return this;
   };
@@ -560,7 +629,6 @@ function locate(req, name) {
  */
 function formatErrors(param, msg, value) {
   var formattedParam = utils.formatParamOutput(param);
-
   return this.errorFormatter(formattedParam, msg, value);
 }
 

--- a/test/wildcardValidationTest.js
+++ b/test/wildcardValidationTest.js
@@ -1,0 +1,68 @@
+var chai = require('chai');
+var expect = chai.expect;
+var request = require('supertest');
+
+var app;
+
+function validation(req, res) {
+  req.checkBody('users.*.email', 'valid email required').isEmail();
+  req.checkBody('users.*.accessRights.*', 'valid access rights required').isInt();
+  req.checkBody(['users', '*', 'accessRights', 'execute'], 'execite rigths required').notEmpty();
+
+  var errors = req.validationErrors();
+  if (errors) {
+    return res.send(errors);
+  }
+  res.send(req.body);
+}
+
+function testRoute(path, data, test, done) {
+  request(app)
+    .post(path)
+    .send(data)
+    .end(function (err, res) {
+      test(res.body);
+      done();
+    });
+}
+
+// This before() is required in each set of tests in
+// order to use a new validation function in each file
+before(function () {
+  delete require.cache[require.resolve('./helpers/app')];
+  app = require('./helpers/app')(validation);
+});
+
+describe('wildcard array/object validation', function () {
+  it('should return a success when the correct data is passed on the body', function (done) {
+    var users = [
+            { email: 'test1@mail.com', accessRights: { read: 0, write: 7, execute: 3 } },
+            { email: 'test2@mail.com', accessRights: { read: 0, write: 7, execute: 3 } },
+            { email: 'test3@mail.com', accessRights: { read: 0, write: 7, execute: 3 } },
+            { email: 'test4@mail.com', accessRights: { read: 0, write: 7, execute: 3 } }
+    ];
+    var validateBody = function (body) {
+      expect(body).to.have.a.property('users').eql(users);
+    };
+
+    testRoute('/', { users: users}, validateBody, done);
+  });
+
+  it('should return an error object with each failing param as a property when the data is invalid', function (done) {
+    var badUsers = [
+            { email: 'bad email', accessRights: { read: 0, write: 'the baddie', execute: 3 } },
+            { email: 'test2@mail.com', accessRights: { read: 0, write: 7, execute: 3 } },
+            { email: 'test3@mail.com', accessRights: { read: 0, write: 7, execute: 3 } },
+            { email: 'test4@mail.com', accessRights: { read: 0, write: 3} }
+    ];
+    var checkErrors = function (body) {
+      expect(body).to.eql([
+            { param: 'users.0.email', msg: 'valid email required', value: 'bad email' },
+            { param: 'users.0.accessRights.write', msg: 'valid access rights required', value: 'the baddie' },
+            { param: 'users.3.accessRights.execute', msg: 'execite rigths required' }]
+          );
+    };
+
+    testRoute('/', { users: badUsers }, checkErrors, done);
+  });
+});


### PR DESCRIPTION
Hi! This is an another implementation of wildcard-based validation of array-like objects. Pretty similar to  ctavan/express-validator#234, but don't depends on additional third party modules.

**Definition**
```js
req.checkBody('users.*.email', 'valid email required').isEmail();
req.checkBody('users.*.accessRights.*', 'valid access rights required').isInt();
req.checkBody(['users', '*', 'accessRights', 'execute'], 'execute rights required').notEmpty();
```

**Request**
```json
{
    "users": [
        { "email": "bad email", "accessRights": { "read": 0, "write": "the baddie", "execute": 3 } },
        { "email": "test2@mail.com", "accessRights": { "read": 0, "write": 7, "execute": 3 } },
        { "email": "test3@mail.com", "accessRights": { "read": 0, "write": 7, "execute": 3 } },
        { "email": "test4@mail.com", "accessRights": { "read": 0, "write": 3 } }
    ]
}
```

**Response**
```json
[
    { "param": "users.0.email", "msg": "valid email required", "value": "bad email" },
    { "param": "users.0.accessRights.write", "msg": "valid access rights required", "value": "the baddie" },
    { "param": "users.3.accessRights.execute", "msg": "execute rights required" }
]
```



