### PR TITLE
Add optionalNil function

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -159,6 +159,12 @@ var expressValidator = function(options) {
     return this;
   };
 
+  ValidatorChain.prototype.optionalNil = function() {
+    this.skipValidating = _.isNil(this.value);
+
+    return this;
+  };
+
   ValidatorChain.prototype.withMessage = function(message) {
     if (this.lastError) {
       if (this.lastError.isAsync) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Gustavo Henke <guhenke@gmail.com>",
     "Ayman Nedjmeddine <theycallmethedr@gmail.com>"
   ],
-  "version": "3.1.2",
+  "version": "3.2.0",
   "homepage": "https://github.com/ctavan/express-validator",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
There are 2 reasons for doing this rather than using the existing `optional`. First, doing `optional({checkFalsy: true})` is too long/tedious. Secondly, `!this.value` does not handle the case when `value === false`. By that I mean I only want to skip validation if `value` is null or undefined but not if the value is `false` or `''`.

BTW, thanks for doing this repo, this is great.