### PR TITLE
Move @types from devDependency to dependency section

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "@types/bluebird": "~3.0.36",
-    "@types/express": "~4.0.34",
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",
     "validator": "~6.2.0"
   },
   "devDependencies": {
+    "@types/bluebird": "~3.0.36",
+    "@types/express": "~4.0.34",
     "body-parser": "1.12.3",
     "chai": "2.3.0",
     "cookie-parser": "1.4.1",


### PR DESCRIPTION
I install only dependecies to production server, but I installed @types. I think it's bad.