### PR TITLE
Reduce module state to improve testability

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -49,49 +49,6 @@ var additionalValidators = ['contains', 'equals', 'matches'];
 var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'unescape', 'stripLow', 'whitelist', 'blacklist', 'normalizeEmail'];
 
 /**
- * Initializes a chain of validators
- *
- * @class
- * @param  {(string|string[])}  param         path to property to validate
- * @param  {string}             failMsg       validation failure message
- * @param  {Request}            req           request to attach validation errors
- * @param  {string}             location      request property to find value (body, params, query, etc.)
- * @param  {object}             options       options containing error formatter
- */
-
-function ValidatorChain(param, failMsg, req, location, options) {
-  this.errorFormatter = options.errorFormatter;
-  this.param = param;
-  this.value = location ? _.get(req[location], param) : undefined;
-  this.validationErrors = [];
-  this.failMsg = failMsg;
-  this.req = req;
-  this.lastError = null; // used by withMessage to get the values of the last error
-  return this;
-}
-
-
-/**
- * Initializes a sanitizer
- *
- * @class
- * @param  {(string|string[])}  param    path to property to sanitize
- * @param  {[type]}             req             request to sanitize
- * @param  {[string]}           locations        request property to find value
- */
-
-function Sanitizer(param, req, locations) {
-  this.values = locations.map(function(location) {
-    return _.get(req[location], param);
-  });
-
-  this.req = req;
-  this.param = param;
-  this.locations = locations;
-  return this;
-}
-
-/**
  * Adds validation methods to request object via express middleware
  *
  * @method expressValidator
@@ -114,6 +71,139 @@ var expressValidator = function(options) {
   };
 
   _.defaults(options, defaults);
+
+  /**
+   * Initializes a chain of validators
+   *
+   * @class
+   * @param  {(string|string[])}  param         path to property to validate
+   * @param  {string}             failMsg       validation failure message
+   * @param  {Request}            req           request to attach validation errors
+   * @param  {string}             location      request property to find value (body, params, query, etc.)
+   * @param  {object}             options       options containing error formatter
+   */
+
+  function ValidatorChain(param, failMsg, req, location, options) {
+    this.errorFormatter = options.errorFormatter;
+    this.param = param;
+    this.value = location ? _.get(req[location], param) : undefined;
+    this.validationErrors = [];
+    this.failMsg = failMsg;
+    this.req = req;
+    this.lastError = null; // used by withMessage to get the values of the last error
+    return this;
+  }
+
+  /**
+   * Initializes a sanitizer
+   *
+   * @class
+   * @param  {(string|string[])}  param    path to property to sanitize
+   * @param  {[type]}             req             request to sanitize
+   * @param  {[string]}           locations        request property to find value
+   */
+
+  function Sanitizer(param, req, locations) {
+    this.values = locations.map(function(location) {
+      return _.get(req[location], param);
+    });
+
+    this.req = req;
+    this.param = param;
+    this.locations = locations;
+    return this;
+  }
+
+  /**
+   * validate an object using a schema, using following format:
+   *
+   * {
+   *   paramName: {
+   *     validatorName: true,
+   *     validator2Name: true
+   *   }
+   * }
+   *
+   * Pass options or a custom error message:
+   *
+   * {
+   *   paramName: {
+   *     validatorName: {
+   *       options: ['', ''],
+   *       errorMessage: 'An Error Message'
+   *     }
+   *   }
+   * }
+   *
+   * @method validateSchema
+   * @param  {Object}       schema    schema of validations
+   * @param  {Request}      req       request to attach validation errors
+   * @param  {string}       loc  request property to find value (body, params, query, etc.)
+   * @param  {Object}       options   options containing custom validators & errorFormatter
+   * @return {object[]}               array of errors
+   */
+
+  function validateSchema(schema, req, loc, options) {
+    var locations = ['body', 'params', 'query', 'headers'],
+      currentLoc = loc;
+
+    for (var param in schema) {
+
+      // check if schema has defined location
+      if (schema[param].hasOwnProperty('in')) {
+        if (locations.indexOf(schema[param].in) !== -1) {
+          currentLoc = schema[param].in;
+        } else {
+          // skip params where defined location is not supported
+          continue;
+        }
+      } else {
+        currentLoc = loc === 'any' ? locate(req, param) : currentLoc;
+      }
+
+      var validator = new ValidatorChain(param, null, req, currentLoc, options);
+      var paramErrorMessage = schema[param].errorMessage;
+
+      var opts;
+
+      if (schema[param].optional) {
+        validator.optional.apply(validator, schema[param].optional.options);
+
+        if (validator.skipValidating) {
+          validator.failMsg = schema[param].optional.errorMessage || paramErrorMessage || 'Invalid param';
+          continue; // continue with the next param in schema
+        }
+      }
+
+      for (var methodName in schema[param]) {
+        if (methodName === 'in') {
+          /* Skip method if this is location definition, do not validate it.
+          * Restore also the original location that was changed only for this particular param.
+          * Without it everything after param with in field would be validated against wrong location.
+          */
+          currentLoc = loc;
+          continue;
+        }
+
+        if (methodName === 'errorMessage') {
+          /* Also do not validate if methodName
+          * represent parameter error message
+          */
+          continue;
+        }
+
+        validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
+
+        opts = schema[param][methodName].options;
+
+        if (opts != null && !Array.isArray(opts)) {
+          opts = [opts];
+        }
+
+        validator[methodName].apply(validator, opts);
+      }
+    }
+  }
 
   // _.set validators and sanitizers as prototype methods on corresponding chains
   _.forEach(validator, function(method, methodName) {
@@ -355,97 +445,6 @@ var expressValidator = function(options) {
     next();
   };
 };
-
-/**
- * validate an object using a schema, using following format:
- *
- * {
- *   paramName: {
- *     validatorName: true,
- *     validator2Name: true
- *   }
- * }
- *
- * Pass options or a custom error message:
- *
- * {
- *   paramName: {
- *     validatorName: {
- *       options: ['', ''],
- *       errorMessage: 'An Error Message'
- *     }
- *   }
- * }
- *
- * @method validateSchema
- * @param  {Object}       schema    schema of validations
- * @param  {Request}      req       request to attach validation errors
- * @param  {string}       loc  request property to find value (body, params, query, etc.)
- * @param  {Object}       options   options containing custom validators & errorFormatter
- * @return {object[]}               array of errors
- */
-
-function validateSchema(schema, req, loc, options) {
-  var locations = ['body', 'params', 'query', 'headers'],
-    currentLoc = loc;
-
-  for (var param in schema) {
-
-    // check if schema has defined location
-    if (schema[param].hasOwnProperty('in')) {
-      if (locations.indexOf(schema[param].in) !== -1) {
-        currentLoc = schema[param].in;
-      } else {
-        // skip params where defined location is not supported
-        continue;
-      }
-    } else {
-      currentLoc = loc === 'any' ? locate(req, param) : currentLoc;
-    }
-
-    var validator = new ValidatorChain(param, null, req, currentLoc, options);
-    var paramErrorMessage = schema[param].errorMessage;
-
-    var opts;
-
-    if (schema[param].optional) {
-      validator.optional.apply(validator, schema[param].optional.options);
-
-      if (validator.skipValidating) {
-        validator.failMsg = schema[param].optional.errorMessage || paramErrorMessage || 'Invalid param';
-        continue; // continue with the next param in schema
-      }
-    }
-
-    for (var methodName in schema[param]) {
-      if (methodName === 'in') {
-        /* Skip method if this is location definition, do not validate it.
-         * Restore also the original location that was changed only for this particular param.
-         * Without it everything after param with in field would be validated against wrong location.
-         */
-        currentLoc = loc;
-        continue;
-      }
-
-      if (methodName === 'errorMessage') {
-        /* Also do not validate if methodName
-         * represent parameter error message
-         */
-        continue;
-      }
-
-      validator.failMsg = schema[param][methodName].errorMessage || paramErrorMessage || 'Invalid param';
-
-      opts = schema[param][methodName].options;
-
-      if (opts != null && !Array.isArray(opts)) {
-        opts = [opts];
-      }
-
-      validator[methodName].apply(validator, opts);
-    }
-  }
-}
 
 /**
  * Validates and handles errors, return instance of itself to allow for chaining

--- a/test/testabilityTest.js
+++ b/test/testabilityTest.js
@@ -1,0 +1,61 @@
+
+var chai = require('chai');
+var express = require('express');
+var request = require('supertest');
+var expressValidator = require('../index');
+
+describe('Testability:', function() {
+  describe('validator works with multiple express apps,', function() {
+
+    // This test case:
+    //  - creates two express apps
+    //  - initializes each app with different custom validators of the same name
+    //  - verifies that custom validators declared for one app do not
+    //    contaminate the other app's validators
+    it('custom validators do not contaminate other sessions', function(done) {
+      var happyApp = express();
+      var angryApp = express();
+      chai.assert(happyApp !== angryApp, 'express app is not a singleton');
+
+      // Happy express app has a custom validator which always returns true
+      happyApp.use(expressValidator({
+        customValidators: {alpha: function() { return true }}
+      }));
+
+      // Angry express app has a custom validator which always returns false
+      //  - angryApp isn't actually explicitly used in this case
+      angryApp.use(expressValidator({
+        customValidators: {alpha: function() { return false }}
+      }));
+
+      // Middleware to assert that validation happens without errors
+      happyApp.use(function(req, res) {
+
+        // Perform validation with the custom validator
+        req.check('alpha').alpha();
+
+        // Get the validation result from express-validator
+        //  - assert that there were no errors
+        //  - respond via express appropriately (status 200 or 500)
+        return req.getValidationResult()
+          .then(function(result) {
+            var noErrors = result.isEmpty();
+            chai.assert(noErrors, 'custom validators are not overwritten');
+            if (noErrors) {
+              res.status(200).send('cool');
+            } else {
+              res.status(500).send('not-cool');
+            }
+          })
+          .catch(function(error) { done(error); })
+      });
+
+      // Launch a test request to the happy express app
+      request(happyApp)
+        .get('/')
+        .send({alpha: '123'})
+        .expect(200)
+        .end(function(err) { done(err); });
+    });
+  });
+});


### PR DESCRIPTION
Hello!

At the company I work for called INgrooves, we use `express-validator` in several applications — we thank all contributors of this project for an excellent tool!

Recently, we uncovered a bug in express-validator, which this PR fixes.
 - each of our apps used express-validator and some `customValidators`
 - we merged a few of these apps together into a single app, and experienced breakage — because `express-validator` keeps its `customValidators` in module-level state — the custom validators for route B overwrite the custom validators for route A, etc

This PR fixes the problem by simply moving this global state within the express validator constructor's scope
 - thus now each call to express validator has its own private ValidationChain prototype to work with (also internalized Sanitizer and the validateSchema function)
 - subsequent express validator calls won't contaminate previous calls

I say this improves testability, but in our case, the fix was necessary for our application to run (not tests) — this fix will certainly help anybody using `express-validator` in an async-testing situation.