### PR TITLE
declare trim parameter as optional in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -262,9 +262,9 @@ declare namespace ExpressValidator {
      * Trim characters (whitespace by default) from both sides of the input.
      * @param chars Defaults to whitespace
      */
-    trim(chars: string): Sanitizer;
-    ltrim(chars: string): Sanitizer;
-    rtrim(chars: string): Sanitizer;
+    trim(chars?: string): Sanitizer;
+    ltrim(chars?: string): Sanitizer;
+    rtrim(chars?: string): Sanitizer;
     /**
      * Remove characters with a numerical value < 32 and 127, mostly control characters.
      * Unicode-safe in JavaScript.

--- a/test/typeDefinitionTest.ts
+++ b/test/typeDefinitionTest.ts
@@ -26,6 +26,8 @@ app.use((req: express.Request, res: express.Response, next: express.NextFunction
     .toFloat()
     .toInt().toInt(10)
     .toBoolean().toBoolean(true)
+    .trim()
+    .ltrim().rtrim()
     .trim('')
     .ltrim('').rtrim('')
     .stripLow().stripLow(true)


### PR DESCRIPTION
trim, ltrim, and rtrim should be usable without parameter using typescript.