### PR TITLE
REF #350 Fix for TypeScript Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,16 +10,17 @@
 declare namespace Express {
   interface Request extends ExpressValidator.RequestValidation {}
 }
+
+// External express-validator module.
+declare module "express-validator" {
   import express = require('express');
 
   /**
    * @param options see: https://github.com/ctavan/express-validator#middleware-options
    * @constructor
    */
-  declare function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;
-
-  export = ExpressValidator;
-
+  export function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;  
+}
 // Internal Module.
 declare namespace ExpressValidator {
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,19 +10,15 @@
 declare namespace Express {
   interface Request extends ExpressValidator.RequestValidation {}
 }
-
-// External express-validator module.
-declare module "express-validator" {
   import express = require('express');
 
   /**
    * @param options see: https://github.com/ctavan/express-validator#middleware-options
    * @constructor
    */
-  function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;
+  declare function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;
 
   export = ExpressValidator;
-}
 
 // Internal Module.
 declare namespace ExpressValidator {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,22 +5,19 @@
 
 ///<reference types="express"/>
 ///<reference types="bluebird"/>
-
+import * as express from 'express';
 // Add RequestValidation Interface on to Express's Request Interface.
-declare namespace Express {
-  interface Request extends ExpressValidator.RequestValidation {}
+declare global {
+  namespace Express {
+    interface Request extends ExpressValidator.RequestValidation { }
+  }
 }
-
-// External express-validator module.
-declare module "express-validator" {
-  import express = require('express');
-
-  /**
-   * @param options see: https://github.com/ctavan/express-validator#middleware-options
-   * @constructor
-   */
-  export function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;  
-}
+/**
+ * @param options see: https://github.com/ctavan/express-validator#middleware-options
+ * @constructor
+ */
+declare function ExpressValidator(options?: ExpressValidator.Options.ExpressValidatorOptions): express.RequestHandler;
+export = ExpressValidator;
 // Internal Module.
 declare namespace ExpressValidator {
 


### PR DESCRIPTION
Without this fix users of TypeScript (at least 2.3.4) unable to import
the library using standard “import” syntax without either a) removing
the typings or b) using “require”.

Fix for #350 