### PR TITLE
Fix `isValid.then` check bug in case validator returns undefined/null

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -18,6 +18,23 @@ var warnAsyncValidationErrors = deprecate(
   'req.asyncValidationErrors() may be removed in a future version. Use req.getValidationResult() instead.'
 );
 
+/**
+ * display warnings once per each validator
+ * which returns null or undefined as a validation
+ * result
+ */
+var warnValidatorNilReturn = (function() {
+  var warned = {};
+  return function(methodName, returnedValue) {
+    if (warned[methodName]) {
+      return;
+    }
+    warned[methodName] = true;
+    console.warn('WARNING: unexpected return value: `' + returnedValue + '` returned by `' + methodName + '` validator');
+  }
+
+}());
+
 // When validator upgraded to v5, they removed automatic string coercion
 // The next few methods (up to validator.init()) restores that functionality
 // so that express-validator can continue to function normally
@@ -493,8 +510,8 @@ function makeValidator(methodName, container) {
 
     var isNilValue = isValid === undefined || isValid === null
 
-    if(isNilValue) {
-      warnValidatorNilReturn(methodName, isValid, this.value);
+    if (isNilValue) {
+      warnValidatorNilReturn(methodName, isValid);
     }
 
     if (!isNilValue && isValid.then) {
@@ -586,20 +603,6 @@ function formatErrors(param, msg, value) {
   return this.errorFormatter(formattedParam, msg, value);
 }
 
-/**
- * display warnings once per each validator
- * which returns null or undefined as a validation
- * result
- */
-var warnValidatorNilReturn = (function() {
-  var warned = {};
-  return function(methodName, returnedValue, value) {
-    if(warned[methodName]) return;
-    warned[methodName] = true;
-    console.warn('WARNING: unexpected return value: `' + returnedValue + '` returned by `' + methodName + '` validator');
-  }
-
-}());
 
 module.exports = expressValidator;
 module.exports.validator = validator;

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -491,7 +491,13 @@ function makeValidator(methodName, container) {
     }
     var error = formatErrors.call(this, this.param, msg || 'Invalid value', this.value);
 
-    if (isValid !== undefined && isValid !== null && isValid.then) {
+    var isNilValue = isValid === undefined || isValid === null
+
+    if(isNilValue) {
+      warnValidatorNilReturn(methodName, isValid, this.value);
+    }
+
+    if (!isNilValue && isValid.then) {
       var promise = isValid.catch(function() {
         return Promise.reject(error);
       });
@@ -579,6 +585,21 @@ function formatErrors(param, msg, value) {
 
   return this.errorFormatter(formattedParam, msg, value);
 }
+
+/**
+ * display warnings once per each validator
+ * which returns null or undefined as a validation
+ * result
+ */
+var warnValidatorNilReturn = (function() {
+  var warned = {};
+  return function(methodName, returnedValue, value) {
+    if(warned[methodName]) return;
+    warned[methodName] = true;
+    console.warn('WARNING: unexpected return value: `' + returnedValue + '` returned by `' + methodName + '` validator');
+  }
+
+}());
 
 module.exports = expressValidator;
 module.exports.validator = validator;

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -491,7 +491,7 @@ function makeValidator(methodName, container) {
     }
     var error = formatErrors.call(this, this.param, msg || 'Invalid value', this.value);
 
-    if (isValid.then) {
+    if (isValid !== undefined && isValid !== null && isValid.then) {
       var promise = isValid.catch(function() {
         return Promise.reject(error);
       });

--- a/test/validatorReturnTest.js
+++ b/test/validatorReturnTest.js
@@ -1,0 +1,49 @@
+var chai = require('chai');
+var expect = chai.expect;
+var Promise = require('bluebird');
+
+describe('#validatorReturn()', function() {
+  before(function() {
+    delete require.cache[require.resolve('../lib/express_validator')];
+  });
+
+  it('should not throw on nil return', function() {
+    var validator = require('../lib/express_validator')({
+      customValidators: {
+        testNull: function() {
+          return null;
+        },
+        testUndefined: function() {
+          return undefined;
+        }
+      }
+    });
+
+    var req = {
+      body: {
+        testParamNull: 1,
+        testParamUndefined: 2
+      }
+    };
+
+    validator(req, {}, function() {});
+
+    var verifyNull = function() {
+      req.check('testParamNull', 'Default Message').testNull()
+    }
+
+    var verifyUndefined = function() {
+      req.check('testParamUndefined', 'Default Message').testUndefined()
+    }
+
+    expect(verifyNull).to.not.throw();
+    expect(verifyUndefined).to.not.throw();
+
+    expect(req.validationErrors()).to.deep.equal([
+      { param: 'testParamNull', msg: 'Default Message', value: 1 },
+      { param: 'testParamUndefined', msg: 'Default Message', value: 2 }
+    ]);
+
+  });
+});
+


### PR DESCRIPTION
I wanted to use the `isUUID` validator. I've set the version as option, like so:
```js
isUUID: {
  options: {
    version: 4
  }
}
```
it turned out, that validator expects the version as a second param instead:

https://github.com/chriso/validator.js/blob/master/lib/isUUID.js#L26

so the version was `{version: 4}` and the line
```js
  var version = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'all';

```
didn't fall back to `all` correctly. Now when it tried to find the pattern, it got undefined:

```js
  var pattern = uuid[version]; // uuid[{version: 4}] does not exist
  return pattern && pattern.test(str);
```

this lib then threw error as it did `undefined.then` [here](https://github.com/ctavan/express-validator/blob/master/lib/express_validator.js#L494).

This PR fixes such issues, however I don't know if it might be better to leave it throw an error so that developer finds out what's actually wrong.