### PR TITLE
Update @types/bluebird package. Closes #357

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "@types/bluebird": "~3.0.36",
+    "@types/bluebird": "^3.4.0",
     "@types/express": "~4.0.34",
     "bluebird": "^3.4.0",
     "lodash": "^4.16.0",


### PR DESCRIPTION
Update `@types/bluebird` to match version of `bluebird`
```
"dependencies": {
    "@types/bluebird": "^3.4.0",
    "bluebird": "^3.4.0",
  }
```