### PR TITLE
Innaccurate dependency claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://img.shields.io/coveralls/ctavan/express-validator.svg)](https://coveralls.io/github/ctavan/express-validator?branch=master)
 
 An [express.js]( https://github.com/visionmedia/express ) middleware for
-[node-validator]( https://github.com/chriso/validator.js ).
+[validator]( https://github.com/chriso/validator.js ).
 
 - [Installation](#installation)
 - [Usage](#usage)


### PR DESCRIPTION
While working with this library, confusion was created by the link title which incorrectly reads 'node-validator', which is not only incorrect, but the link does not take you there.

I know it's petty, but it will hopefully save others time or confusion in the future.

Thanks for the efforts in this library.