### PR TITLE
Version 4 - Wildcard field selection

### DIFF
--- a/check/select-fields.js
+++ b/check/select-fields.js
@@ -1,17 +1,15 @@
 const _ = require('lodash');
+const utils = require('../lib/utils');
 
 module.exports = (req, context) => {
   let allFields = [];
   const optionalityFilter = createOptionalityFilter(context);
 
   context.fields.forEach(field => {
-    let instances = context.locations
-      .map(location => ({
-        location,
-        path: field,
-        value: getInRequest(req, field, location)
-      }))
-      .filter(optionalityFilter);
+    let instances = _(context.locations)
+      .flatMap(createFieldExpander(req, field))
+      .filter(optionalityFilter)
+      .value();
 
     if (instances.length > 1) {
       const withValue = instances.filter(field => field.value !== undefined);
@@ -21,12 +19,41 @@ module.exports = (req, context) => {
     allFields = allFields.concat(instances);
   });
 
-  return allFields;
+  return _.uniqWith(allFields, _.isEqual);
 };
 
-function getInRequest (req, field, location) {
-  field = location === 'headers' ? field.toLowerCase() : field;
-  return _.get(req[location], field);
+function createFieldExpander (req, field) {
+  return location => {
+    const fieldPath = location === 'headers' ? field.toLowerCase() : field;
+    return expand(req[location], fieldPath, []).map(path => ({
+      location,
+      path,
+      value: _.get(req[location], path)
+    }));
+  };
+}
+
+function expand (object, path, paths) {
+  const segments = _.toPath(path);
+  const wildcard = segments.indexOf('*');
+
+  if (wildcard > -1) {
+    const subObject = wildcard ? _.get(object, segments.slice(0, wildcard)) : object;
+    if (!subObject) {
+      return paths;
+    }
+
+    Object.keys(subObject)
+      .map(key => segments
+        .slice(0, wildcard)
+        .concat(key)
+        .concat(segments.slice(wildcard + 1)))
+      .forEach(path => expand(object, path, paths));
+  } else {
+    paths.push(utils.formatParamOutput(segments));
+  }
+
+  return paths;
 }
 
 function createOptionalityFilter ({ optional }) {

--- a/check/select-fields.spec.js
+++ b/check/select-fields.spec.js
@@ -68,6 +68,33 @@ describe('check: field selection', () => {
     });
   });
 
+  it('expands "*" wildcards shallowly', () => {
+    const req = {
+      body: {
+        foo: [{ a: 123, b: 456 }]
+      }
+    };
+
+    const instances = selectFields(req, {
+      // Note that the first expression matches both "a" and "b",
+      // so there's some deduplication expected
+      fields: ['*[0].*', 'foo.*.b'],
+      locations: ['body']
+    });
+
+    expect(instances).to.have.length(2);
+    expect(instances).to.deep.include({
+      path: 'foo[0].a',
+      location: 'body',
+      value: 123
+    });
+    expect(instances).to.deep.include({
+      path: 'foo[0].b',
+      location: 'body',
+      value: 456
+    });
+  });
+
   describe('optional context', () => {
     it('ignores fields which are not present in case of checkFalsy = false', () => {
       const instances = selectFields({

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -67,6 +67,8 @@ validator.init();
 // validators and sanitizers not prefixed with is/to
 var additionalSanitizers = ['trim', 'ltrim', 'rtrim', 'escape', 'unescape', 'stripLow', 'whitelist', 'blacklist', 'normalizeEmail'];
 
+var allLocations = ['params', 'query', 'body', 'headers', 'cookies'];
+
 /**
  * Adds validation methods to request object via express middleware
  *
@@ -112,7 +114,7 @@ var expressValidator = function(options) {
   }
 
   function createValidationChain(field, location, message, req, contexts) {
-    const chain = check([field], [location], message);
+    const chain = check([field], Array.isArray(location) ? location : [location], message);
     contexts.push(chain._context);
 
     chain.notEmpty = () => chain.isLength({ min: 1 });
@@ -164,21 +166,20 @@ var expressValidator = function(options) {
    */
 
   function validateSchema(schema, req, loc, contexts) {
-    var locations = ['body', 'params', 'query', 'headers', 'cookies'],
-      currentLoc = loc;
+    var currentLoc = loc;
 
     for (var param in schema) {
 
       // check if schema has defined location
       if (schema[param].hasOwnProperty('in')) {
-        if (locations.indexOf(schema[param].in) !== -1) {
+        if (allLocations.indexOf(schema[param].in) !== -1) {
           currentLoc = schema[param].in;
         } else {
           // skip params where defined location is not supported
           continue;
         }
       } else {
-        currentLoc = loc === 'any' ? utils.locate(req, param) : currentLoc;
+        currentLoc = loc === 'any' ? allLocations : currentLoc;
       }
 
       const paramErrorMessage = schema[param].errorMessage;
@@ -392,7 +393,7 @@ var expressValidator = function(options) {
       if (_.isPlainObject(param)) {
         return validateSchema(param, req, 'any', contexts);
       }
-      return createValidationChain(param, utils.locate(req, param), failMsg, req, contexts);
+      return createValidationChain(param, allLocations, failMsg, req, contexts);
     };
 
     req.filter = req.sanitize;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,23 +62,3 @@ exports.makeSanitizer = function makeSanitizer(methodName, container) {
     return result;
   };
 }
-
-/**
- * find location of param
- *
- * @method param
- * @param  {Request} req       express request object
- * @param  {(string|string[])} name [description]
- * @return {string}
- */
-exports.locate = function locate(req, name) {
-  if (_.get(req.params, name)) {
-    return 'params';
-  } else if (_.has(req.query, name)) {
-    return 'query';
-  } else if (_.has(req.body, name)) {
-    return 'body';
-  }
-
-  return undefined;
-}

--- a/test/check.spec.js
+++ b/test/check.spec.js
@@ -65,43 +65,21 @@ describe('Legacy: req.check()/req.assert()/req.validate()', () => {
     });
   });
 
-  it('does not check req.headers', () => {
-    const req = {
-      headers: { int: 'asd' }
-    };
-
-    expressValidator()(req, {}, () => {});
-    req.check('int').optional().isInt();
-
-    return req.getValidationResult().then(result => {
-      expect(result.mapped()).to.eql({});
-    });
-  });
-
-  it('does not check req.cookies', () => {
-    const req = {
-      cookies: { int: 'asd' }
-    };
-
-    expressValidator()(req, {}, () => {});
-    req.check('int').optional().isInt();
-
-    return req.getValidationResult().then(result => {
-      expect(result.mapped()).to.eql({});
-    });
-  });
-
-  it('checks req.params, then req.query, then req.body', () => {
+  it('checks req.params, then req.query, then req.body, then req.headers, then req.cookies', () => {
     const req = {
       params: { int: '123' },
       query: { int: 'asd', alpha: 'asd' },
-      body: { int: 'foo', alpha: '123', upper: 'BAR' }
+      body: { int: 'foo', alpha: '123', upper: 'BAR' },
+      headers: { int: 'asd', alpha: '123', upper: 'foo', decimal: '.5' },
+      cookies: { int: 'asd', alpha: '123', upper: 'foo', decimal: '5', json: '{}' }
     };
 
     expressValidator()(req, {}, () => {});
     req.check('int').isInt();
     req.check('alpha').isAlpha();
     req.check('upper').isUppercase();
+    req.check('decimal').isDecimal();
+    req.check('json').isJSON();
 
     return req.getValidationResult().then(result => {
       expect(result.mapped()).to.eql({});
@@ -122,6 +100,22 @@ describe('Legacy: req.check()/req.assert()/req.validate()', () => {
     return req.getValidationResult().then(result => {
       expect(result.mapped()).to.not.have.property('nested.path[0]');
       expect(result.mapped()).to.have.property('nested.path[1]');
+    });
+  });
+
+  it('checks using wildcard * in paths', () => {
+    const req = {
+      params: {
+        foo: { bar: [ 'not_email' ] }
+      }
+    };
+
+    expressValidator()(req, {}, () => {});
+    req.check('*.bar.*').isEmail();
+    req.check('foo.*[0]').isEmail();
+
+    return req.getValidationResult().then(result => {
+      expect(result.mapped()).to.have.property('foo.bar[0]');
     });
   });
 });


### PR DESCRIPTION
Follow-up of #383.

Adds support for wildcard field selection, such as `foo.*.bar` (translates to "every `bar` below a key below `foo`").
There's NO supoprt for deep wildcard searching at this moment, eg `foo.**` (which translates to "everything below `foo`")