### PR TITLE
Version 4 - oneOf

### DIFF
--- a/check/index.d.ts
+++ b/check/index.d.ts
@@ -2,11 +2,11 @@ import * as express from 'express';
 import { Result, Options, Validator } from '../shared-typings';
 
 export const check: ValidationChainBuilder;
-export const checkBody: ValidationChainBuilder;
-export const checkCookies: ValidationChainBuilder;
-export const checkHeaders: ValidationChainBuilder;
-export const checkParams: ValidationChainBuilder;
-export const checkQuery: ValidationChainBuilder;
+export const body: ValidationChainBuilder;
+export const cookie: ValidationChainBuilder;
+export const header: ValidationChainBuilder;
+export const param: ValidationChainBuilder;
+export const query: ValidationChainBuilder;
 export function validationResult (req: express.Request): Result;
 
 export interface ValidationChainBuilder {

--- a/check/index.d.ts
+++ b/check/index.d.ts
@@ -8,6 +8,7 @@ export const header: ValidationChainBuilder;
 export const param: ValidationChainBuilder;
 export const query: ValidationChainBuilder;
 export function validationResult (req: express.Request): Result;
+export function oneOf (chains: ValidationChain[]): express.RequestHandler;
 
 export interface ValidationChainBuilder {
   (field: string | string[], message?: string): ValidationChain;

--- a/check/index.js
+++ b/check/index.js
@@ -1,7 +1,7 @@
 exports.check = require('./check-all');
 exports.body = require('./check-body');
-exports.cookies = require('./check-cookies');
-exports.headers = require('./check-headers');
-exports.params = require('./check-params');
+exports.cookie = require('./check-cookies');
+exports.header = require('./check-headers');
+exports.param = require('./check-params');
 exports.query = require('./check-query');
 exports.validationResult = require('./validation-result');

--- a/check/index.js
+++ b/check/index.js
@@ -5,3 +5,4 @@ exports.header = require('./check-headers');
 exports.param = require('./check-params');
 exports.query = require('./check-query');
 exports.validationResult = require('./validation-result');
+exports.oneOf = require('./one-of');

--- a/check/one-of.js
+++ b/check/one-of.js
@@ -1,0 +1,17 @@
+const runner = require('./runner');
+
+module.exports = validationChains => (req, res, next) => {
+  const promises = validationChains.map(chain => runner(req, chain._context));
+  return Promise.all(promises).then(results => {
+    const empty = results.some(result => result.length === 0);
+    if (empty) {
+      next();
+      return [];
+    }
+
+    req._validationErrors = (req._validationErrors || []).concat(results[0]);
+    next();
+
+    return results[0];
+  }).catch(next);
+};

--- a/check/one-of.spec.js
+++ b/check/one-of.spec.js
@@ -1,0 +1,84 @@
+const { expect } = require('chai');
+const { check, oneOf } = require('./');
+
+describe('check: checkOneOf middleware', () => {
+  it('does not return errors if any chain succeeded', () => {
+    const req = {
+      cookies: { foo: '123', bar: 'abc' }
+    };
+
+    return oneOf([
+      check('foo').isInt(),
+      check('bar').isInt()
+    ])(req, {}, () => {}).then(errors => {
+      expect(errors).to.eql([]);
+    });
+  });
+
+  it('uses first error list in case all chains failed', () => {
+    const req = {
+      cookies: { foo: 'abc', bar: 'def' }
+    };
+
+    return oneOf([
+      check('foo').isInt(),
+      check('bar').isInt()
+    ])(req, {}, () => {}).then(errors => {
+      expect(errors)
+        .to.have.length(1)
+        .and.to.deep.include({
+          location: 'cookies',
+          path: 'foo',
+          value: 'abc',
+          message: 'Invalid value'
+        });
+    });
+  });
+
+  describe('validation errors', () => {
+    it('are not set in the request if any chain succeeded', done => {
+      const req = {
+        cookies: { foo: '123', bar: 'abc' }
+      };
+
+      oneOf([
+        check('foo').isInt(),
+        check('bar').isInt()
+      ])(req, {}, () => {
+        expect(req).to.not.have.property('_validationErrors');
+        done();
+      });
+    });
+
+    it('are pushed to req._validationErrors', done => {
+      const req = {
+        body: { foo: 'not_email' }
+      };
+
+      oneOf([
+        check('foo').isEmail(),
+        check('foo').isNumeric()
+      ])(req, {}, () => {
+        expect(req)
+          .to.have.property('_validationErrors')
+          .that.is.an('array')
+          .that.has.lengthOf(1);
+
+        done();
+      });
+    });
+
+    it('are kept from other middleware calls', () => {
+      const req = {
+        query: { foo: '123', bar: 'BAR' }
+      };
+
+      return Promise.all([
+        oneOf([ check('foo').isAlpha() ])(req, {}, () => {}),
+        oneOf([ check('bar').isInt() ])(req, {}, () => {})
+      ]).then(() => {
+        expect(req._validationErrors).to.have.length(2);
+      });
+    });
+  });
+});

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from 'express';
 import {
   check,
-  checkBody,
-  checkHeaders,
-  checkQuery,
-  checkCookies,
-  checkParams,
+  body,
+  header,
+  query,
+  cookie,
+  param,
   validationResult
 } from './'
 
@@ -31,11 +31,11 @@ mappedErrors.foo.param;
 mappedErrors.foo.value;
 
 // Test as middleware
-checkBody('foo');
-checkParams('foo');
-checkQuery('foo');
-checkCookies('foo');
-checkHeaders('foo');
+body('foo');
+param('foo');
+query('foo');
+cookie('foo');
+header('foo');
 check('foo')(req, res, () => {});
 
 // Test validation chain methods

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -6,6 +6,7 @@ import {
   query,
   cookie,
   param,
+  oneOf,
   validationResult
 } from './'
 
@@ -37,6 +38,11 @@ query('foo');
 cookie('foo');
 header('foo');
 check('foo')(req, res, () => {});
+
+oneOf([
+  check('foo').isInt(),
+  check('bar').isDecimal()
+])(req, res, () => {});
 
 // Test validation chain methods
 check('foo', 'with error message')


### PR DESCRIPTION
This is a follow-up of #383.

Creates another middleware function `oneOf`, that will succeed if at least one of the validator chains succeeded.

```js
const { oneOf, check } = require('express-validator/check');

app.post('/', oneOf([
  check('username').isEmail(),
  check('password').isLength({ min: 5 })
], (req, res, next) => {
  // weee
});
```

See #200