### PR TITLE
Version 4 - Get subset of validated data

### DIFF
--- a/check/check.js
+++ b/check/check.js
@@ -11,6 +11,7 @@ module.exports = (fields, locations, message) => {
 
   const middleware = (req, res, next) => {
     return runner(req, middleware._context).then(errors => {
+      req._validationContexts = (req._validationContexts || []).concat(middleware._context);
       req._validationErrors = (req._validationErrors || []).concat(errors);
       next();
     }, next);

--- a/check/one-of.js
+++ b/check/one-of.js
@@ -1,8 +1,12 @@
 const runner = require('./runner');
 
 module.exports = validationChains => (req, res, next) => {
-  const promises = validationChains.map(chain => runner(req, chain._context));
+  const contexts = validationChains.map(chain => chain._context);
+  const promises = contexts.map(context => runner(req, context));
+
   return Promise.all(promises).then(results => {
+    req._validationContexts = (req._validationContexts || []).concat(contexts);
+
     const empty = results.some(result => result.length === 0);
     if (empty) {
       next();

--- a/filter/index.d.ts
+++ b/filter/index.d.ts
@@ -1,0 +1,7 @@
+import * as express from 'express';
+
+export function matchedData (req: express.Request, options?: MatchedDataOptions): { [key: string]: any };
+
+interface MatchedDataOptions {
+  onlyValidData: boolean
+}

--- a/filter/index.js
+++ b/filter/index.js
@@ -1,0 +1,1 @@
+exports.matchedData = require('./matched-data');

--- a/filter/matched-data.js
+++ b/filter/matched-data.js
@@ -1,0 +1,17 @@
+const _ = require('lodash');
+const selectFields = require('../check/select-fields');
+
+module.exports = (req, { onlyValidData = true } = {}) => {
+  const validityFilter = !onlyValidData ? () => true : field => {
+    return !req._validationErrors.find(error =>
+      error.path === field.path &&
+      error.location === field.location
+    );
+  };
+
+  return _(req._validationContexts)
+    .flatMap(context => selectFields(req, context))
+    .filter(validityFilter)
+    .reduce((state, field) => _.set(state, field.path, field.value), {})
+    .valueOf();
+};

--- a/filter/matched-data.spec.js
+++ b/filter/matched-data.spec.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+const { check, oneOf } = require('../check');
+const { matchedData } = require('./');
+
+describe('filter: matchedData', () => {
+  it('includes only valid data in the request', () => {
+    const req = {
+      query: { foo: '123', bar: 'abc', baz: 'def' },
+      body: { foo: 'abc' }
+    };
+
+    return check(['foo', 'bar']).isInt()(req, {}, () => {}).then(() => {
+      const data = matchedData(req);
+      expect(data).to.eql({ foo: '123' });
+    });
+  });
+
+  it('sets paths properly even when using wildcards', () => {
+    const req = {
+      body: { foo: [10, 20, 30] },
+      query: { bar: { baz: { qux: 123 } } }
+    };
+
+    return check(['foo.*', '*.*.qux']).isInt()(req, {}, () => {}).then(() => {
+      const data = matchedData(req);
+
+      expect(data).to.eql({
+        foo: [10, 20, 30],
+        bar: { baz: { qux: 123 } }
+      });
+    });
+  });
+
+  describe('when { onlyValidData: false } flag is passed', () => {
+    it('returns object with all data validated in the request', () => {
+      const req = {
+        query: { foo: '123', bar: 'abc', baz: 'def' }
+      };
+
+      return check(['foo', 'bar']).isInt()(req, {}, () => {}).then(() => {
+        const data = matchedData(req, { onlyValidData: false });
+
+        expect(data).to.eql({
+          foo: '123',
+          bar: 'abc'
+        });
+      });
+    });
+
+    it('includes data from every chain in oneOf', () => {
+      const req = {
+        headers: { foo: 'foo', bar: 'bar', baz: 'baz' }
+      };
+
+      return oneOf([
+        check('foo').isInt(),
+        check('bar').isInt()
+      ])(req, {}, () => {}).then(() => {
+        const data = matchedData(req, { onlyValidData: false });
+
+        expect(data).to.eql({
+          foo: 'foo',
+          bar: 'bar'
+        });
+      });
+    });
+  });
+});

--- a/filter/type-definition.spec.ts
+++ b/filter/type-definition.spec.ts
@@ -1,0 +1,7 @@
+import { Request } from 'express';
+import { matchedData } from './';
+
+const req: Request = <Request>{};
+
+matchedData(req).foo;
+matchedData(req, { onlyValidData: true }).bar;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 check/**/*.js
+filter/**/*.js
 test/**/*.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,9 @@
     "strictNullChecks": true,
     "outDir": "./build"
   },
-  "files": [
-    "index.d.ts",
-    "shared-typings.d.ts",
-    "check/index.d.ts",
-    "./check/type-definition.spec.ts",
-    "./test/type-definition.spec.ts"
+  "include": [
+    "**/*.d.ts",
+    "**/*.spec.ts"
   ],
   "exclude": [ "node_modules", "coverage" ]
 }


### PR DESCRIPTION
This is a follow-up of #383.

Adds a helper function to retrieve the subset of data validated in the current request, as requested in #168.
This can include only the valid data or all data (even invalid ones).

```js
const { check } = require('express-validator/check');
const { matchedData } = require('express-validator/filter');
app.post('/login', [
  check('username').isEmail(),
  check('password').isLength({ min: 5 })
], (req, res, next) => {
  const data = matchedData(req);
  // yay data should contain only { username, password } now
});
```