### PR TITLE
check API - error formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This will have precedence over errors thrown by a custom validator.
 ## Validation Result API
 This is an unified API for dealing with errors, both in legacy and check APIs.
 
-Each error returned by `.array()` and `.mapped()` methods have the following format:
+Each error returned by `.array()` and `.mapped()` methods have the following format by default:
 
 ```js
 {
@@ -238,6 +238,11 @@ Each error returned by `.array()` and `.mapped()` methods have the following for
 
 ### `.isEmpty()`
 > *Returns:* a boolean indicating whether this result object contains no errors at all.
+
+### `.formatWith(formatter)`
+- `formatter(error)`: the function to use to format when returning errors.  
+  The `error` argument is an object in the format of `{ location, msg, param, value, nestedErrors }`, as described above.
+> *Returns:* this validation result instance
 
 ### `.array([options])`
 - `options` *(optional)*: an object of options. Defaults to `{ onlyFirstError: false }`
@@ -284,7 +289,7 @@ app.use(expressValidator(middlewareOptions));
 ```
 
 ### Middleware options
-- `errorFormatter (param, msg, value)`: a function that formats the error objects before returning them to your route handlers.
+- `errorFormatter (param, msg, value, location)`: a function that formats the error objects before returning them to your route handlers.
 - `customValidators`: an object where you can specify custom validators.  
 The key will be the name of the validator, while the value is the validation function, receiving the value and any option.
 - `customSanitizers`: an object where you can specify custom sanitizers.  

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -16,6 +16,12 @@ const res: Response = <Response>{};
 // Test results
 const result = validationResult(req);
 result.isEmpty();
+result.formatWith(error => {
+  error.msg;
+  error.location;
+  error.param;
+  error.value;
+});
 
 const arrayErrors = result.array();
 arrayErrors[0].location;

--- a/check/validation-result.js
+++ b/check/validation-result.js
@@ -1,10 +1,12 @@
 module.exports = req => decorateAsValidationResult({}, req._validationErrors);
 
 function decorateAsValidationResult(obj, errors) {
+  let formatter = error => error;
+
   obj.isEmpty = () => !errors.length;
   obj.array = ({ onlyFirstError } = {}) => {
     const used = {};
-    return !onlyFirstError ? errors : errors.filter(error => {
+    let filteredErrors = !onlyFirstError ? errors : errors.filter(error => {
       if (used[error.param]) {
         return false;
       }
@@ -12,19 +14,26 @@ function decorateAsValidationResult(obj, errors) {
       used[error.param] = true;
       return true;
     });
+
+    return filteredErrors.map(formatter);
   };
 
   obj.mapped = () => errors.reduce((mapping, error) => {
     if (!mapping[error.param]) {
-      mapping[error.param] = error;
+      mapping[error.param] = formatter(error);
     }
 
     return mapping;
   }, {});
 
+  obj.formatWith = errorFormatter => {
+    formatter = errorFormatter;
+    return obj;
+  };
+
   obj.throw = () => {
     if (errors.length) {
-      throw decorateAsValidationResult(new Error('Validation failed'), errors);
+      throw decorateAsValidationResult(new Error('Validation failed'), errors).formatWith(formatter);
     }
   };
 

--- a/check/validation-result.spec.js
+++ b/check/validation-result.spec.js
@@ -41,6 +41,21 @@ describe('check: validationResult', () => {
         msg: 'yay'
       });
     });
+
+    it('formats using formatter passed via .formatWith()', () => {
+      const result = validationResult({ _validationErrors: allErrors }).formatWith(error => {
+        return Object.assign({ code: 'foo' }, error);
+      });
+
+      let errors = result.array();
+      expect(errors[0]).to.have.property('code', 'foo');
+      expect(errors[1]).to.have.property('code', 'foo');
+      expect(errors[2]).to.have.property('code', 'foo');
+
+      errors = result.array({ onlyFirstError: true });
+      expect(errors[0]).to.have.property('code', 'foo');
+      expect(errors[1]).to.have.property('code', 'foo');
+    });
   });
 
   describe('.mapped()', () => {
@@ -49,6 +64,17 @@ describe('check: validationResult', () => {
       expect(result.mapped()).to.eql({
         foo: { param: 'foo', msg: 'blabla' },
         bar: { param: 'bar', msg: 'yay' }
+      });
+    });
+
+    it('formats using formatter passed via .formatWith()', () => {
+      const result = validationResult({ _validationErrors: allErrors }).formatWith(error => {
+        return Object.assign({ code: 'bar' }, error);
+      });
+
+      expect(result.mapped()).to.eql({
+        foo: { param: 'foo', msg: 'blabla', code: 'bar' },
+        bar: { param: 'bar', msg: 'yay', code: 'bar' }
       });
     });
   });
@@ -74,6 +100,20 @@ describe('check: validationResult', () => {
       } catch (e) {
         expect(e).to.respondTo('mapped');
         expect(e).to.respondTo('array');
+        done();
+      }
+    });
+
+    it('passes previous formatter to the thrown error', done => {
+      const result = validationResult({ _validationErrors: allErrors }).formatWith(error => {
+        return Object.assign({ code: 'foo' }, error);
+      });
+
+      try {
+        result.throw();
+        done(new Error('no errors thrown'));
+      } catch (e) {
+        expect(e.array()).to.have.deep.property('[0].code', 'foo');
         done();
       }
     });

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -82,8 +82,9 @@ var expressValidator = function(options) {
   var defaults = {
     customValidators: {},
     customSanitizers: {},
-    errorFormatter: function(param, msg, value) {
+    errorFormatter: function(param, msg, value, location) {
       return {
+        location,
         param: param,
         msg: msg,
         value: value
@@ -220,6 +221,14 @@ var expressValidator = function(options) {
     }
   }
 
+  /**
+   * Error formatter delegator to the legacy format
+   * @param {*} error
+   */
+  function errorFormatter({ param, msg, value, location }) {
+    return options.errorFormatter(param, msg, value, location);
+  }
+
   // _.set sanitizers as prototype methods on corresponding chains
   _.forEach(validator, function(method, methodName) {
     if (methodName.match(/^to/) || _.includes(additionalSanitizers, methodName)) {
@@ -241,14 +250,15 @@ var expressValidator = function(options) {
 
         const promises = context.validators.map(validatorCfg => {
           const result = validatorCfg.validator(field.value, ...validatorCfg.options);
-          const errorObj = options.errorFormatter(
-            utils.formatParamOutput(field.path),
-            utils.replaceArgs(
+          const errorObj = {
+            location: field.location,
+            value: field.value,
+            param: utils.formatParamOutput(field.path),
+            msg: utils.replaceArgs(
               validatorCfg.message || context.message || 'Invalid value',
               [field.value, ...validatorCfg.options]
-            ),
-            field.value
-          );
+            )
+          };
 
           if (result && result.then) {
             req._asyncValidationErrors.push(result.then(() => {
@@ -284,7 +294,7 @@ var expressValidator = function(options) {
       warnValidationErrors();
       runContexts();
 
-      var result = validationResult(req);
+      var result = validationResult(req).formatWith(errorFormatter);
       if (result.isEmpty()) {
         return false;
       }
@@ -307,7 +317,7 @@ var expressValidator = function(options) {
     req.getValidationResult = function() {
       runContexts();
       return Promise.all(req._asyncValidationErrors).then(() => {
-        return validationResult(req);
+        return validationResult(req).formatWith(errorFormatter);
       });
     };
 

--- a/shared-typings.d.ts
+++ b/shared-typings.d.ts
@@ -136,6 +136,11 @@ export interface Result {
   isEmpty(): boolean
 
   /**
+   * @return The current validation result instance
+   */
+  formatWith(formatter: ErrorFormatter): this;
+
+  /**
    * @return All errors for all validated parameters will be included, unless you specify that you want only the first
    * error of each param by invoking `result.useFirstErrorOnly()`.
    */
@@ -158,12 +163,16 @@ export interface Result {
   throw(): Result
 }
 
+export interface ErrorFormatter {
+  (error: { location: Location, param: string, msg: any, value: any }): any;
+}
+
 declare namespace Options {
 
   export interface ExpressValidatorOptions {
     customValidators?: { [validatorName: string]: (...value: any[]) => boolean | Promise<any> }
     customSanitizers?: { [sanitizername: string]: (value: any) => any }
-    errorFormatter?: (param?: string, msg?: string, value?: any) => any
+    errorFormatter?: (param?: string, msg?: string, value?: any, location?: Location) => any
   }
 
   interface ResultArrayOptions {

--- a/test/errorFormatter.spec.js
+++ b/test/errorFormatter.spec.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect;
 const expressValidator = require('..');
 
 describe('Legacy: Error formatting', () => {
-  it('returns object { msg, value, param } by default', () => {
+  it('returns object { msg, value, param, location } by default', () => {
     const req = {
       headers: { int: 'asd' }
     };
@@ -12,6 +12,7 @@ describe('Legacy: Error formatting', () => {
 
     return req.getValidationResult().then(result => {
       expect(result.mapped().int).to.eql({
+        location: 'headers',
         param: 'int',
         value: 'asd',
         msg: 'Invalid value'
@@ -25,7 +26,8 @@ describe('Legacy: Error formatting', () => {
     };
 
     expressValidator({
-      errorFormatter: (param, msg, value) => ({
+      errorFormatter: (param, msg, value, location) => ({
+        location,
         param,
         value,
         msg: 'Imma real cool'
@@ -36,6 +38,7 @@ describe('Legacy: Error formatting', () => {
 
     return req.getValidationResult().then(result => {
       expect(result.mapped().int).to.eql({
+        location: 'headers',
         param: 'int',
         value: 'asd',
         msg: 'Imma real cool'

--- a/test/type-definition.spec.ts
+++ b/test/type-definition.spec.ts
@@ -16,7 +16,7 @@ app.use(validator({
     isAsync: () => Promise.resolve(true)
   },
   customSanitizers: { toAwesome: (lib: any) => [lib] },
-  errorFormatter: (param: string, msg: string, value: any) => ({ param, msg, value })
+  errorFormatter: (param: string, msg: string, value: any, location: any) => ({ param, msg, value, location })
 }));
 
 app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -207,8 +207,16 @@ app.use((req: express.Request, res: express.Response, next: express.NextFunction
   // getting result
 
   req.getValidationResult()
+    .then(result => {
+      result.formatWith(error => {
+        error.msg;
+        error.location;
+        error.param;
+        error.value;
+      });
 
-    .then(result => result.isEmpty() ? next() : result.throw())
+      result.isEmpty() ? next() : result.throw()
+    })
 
     .catch(result =>
       next({


### PR DESCRIPTION
Add to the Validation Result API a method `.formatWith(formatter)`.
Closes #392 
