### PR TITLE
Sanitizers in the validation chain API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ app.post('/user', [
     // You can customize per validator messages with .withMessage()
     .isEmail().withMessage('must be an email')
 
+    // Every sanitizer method in the validator lib is available as well!
+    .trim()
+    .normalizeEmail()
+
     // ...or throw your own errors using validators created with .custom()
     .custom(value => {
       return findUserByEmail(value).then(user => {
@@ -169,7 +173,8 @@ You can include invalid data by passing the option `onlyValidData` as `false`.
 ---
 
 ## Validation Chain API
-Any of the validation methods listed by [validator.js](https://github.com/chriso/validator.js) are made available in all validation chains created by express-validator, as long as we're supporting the most up-to-date validator version.
+Any of the validation and sanitization methods listed by [validator.js](https://github.com/chriso/validator.js) are made available in all validation chains created by express-validator, as long as we're supporting the most up-to-date validator version.  
+If you use any of the sanitizers together with validators, the validated value is the sanitized one.
 
 Additionally, the following methods are also available:
 

--- a/check/check.spec.js
+++ b/check/check.spec.js
@@ -16,6 +16,25 @@ describe('check: low-level middleware', () => {
     expect(chain).to.have.property('matches');
   });
 
+  it('returns chain with all validator\'s sanitization methods', () => {
+    const chain = check('foo', []);
+    Object.keys(validator)
+      .filter(methodName => methodName.startsWith('to'))
+      .forEach(methodName => {
+        expect(chain).to.have.property(methodName);
+      });
+
+    expect(chain).to.have.property('blacklist');
+    expect(chain).to.have.property('escape');
+    expect(chain).to.have.property('unescape');
+    expect(chain).to.have.property('normalizeEmail');
+    expect(chain).to.have.property('ltrim');
+    expect(chain).to.have.property('rtrim');
+    expect(chain).to.have.property('trim');
+    expect(chain).to.have.property('stripLow');
+    expect(chain).to.have.property('whitelist');
+  });
+
   it('is built with field search locations set via 2rd arg', () => {
     const chain = check('foo', ['foo', 'bar']);
     expect(chain._context)
@@ -74,6 +93,18 @@ describe('check: low-level middleware', () => {
 
       expect(validators[0].validator(undefined)).to.be.false;
       expect(validators[0].validator(null)).to.be.true;
+    });
+  });
+
+  describe('sanitization methods', () => {
+    it('add a sanitizer to the chain context', () => {
+      const chain = check('foo').trim();
+
+      expect(chain._context.sanitizers).to.have.length(1);
+      expect(chain._context.sanitizers).to.deep.include({
+        sanitizer: validator.trim,
+        options: []
+      });
     });
   });
 

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -132,6 +132,36 @@ check('foo', 'with error message')
   .equals(true).equals(0).equals('').equals({}).contains('')
   .matches('').matches('', '').matches(/ /, '')
   .optional().optional({ checkFalsy: true })
+  .trim()
+  .trim('abc')
+  .ltrim()
+  .ltrim('abc')
+  .rtrim()
+  .rtrim('abc')
+  .blacklist('a')
+  .whitelist('z')
+  .escape()
+  .unescape()
+  .toInt()
+  .toInt(10)
+  .toFloat()
+  .toDate()
+  .stripLow()
+  .stripLow(true)
+  .normalizeEmail()
+  .normalizeEmail({
+    all_lowercase: true,
+    gmail_lowercase: true,
+    gmail_remove_dots: true,
+    gmail_remove_subaddress: true,
+    gmail_convert_googlemaildotcom: true,
+    outlookdotcom_lowercase: true,
+    outlookdotcom_remove_subaddress: true,
+    yahoo_lowercase: true,
+    yahoo_remove_subaddress: true,
+    icloud_lowercase: true,
+    icloud_remove_subaddress: true
+  })
   .withMessage(new Error('message'))
   .withMessage(2)
   .withMessage('message');

--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -88,6 +88,11 @@ var expressValidator = function(options) {
     this.req = req;
     this.param = param;
     this.locations = locations;
+
+    req[sanitizerSymbol].forEach(customSanitizers => {
+      utils.mapAndExtend(customSanitizers, Sanitizer.prototype, utils.makeSanitizer);
+    });
+
     return this;
   }
 
@@ -107,6 +112,18 @@ var expressValidator = function(options) {
             validator: customValidators[name]
           });
           chain._context.negateNext = false;
+          return chain;
+        };
+      });
+    });
+
+    req[sanitizerSymbol].forEach(customSanitizers => {
+      Object.keys(customSanitizers).forEach(name => {
+        chain[name] = (...options) => {
+          chain._context.sanitizers.push({
+            options,
+            sanitizer: customSanitizers[name]
+          });
           return chain;
         };
       });
@@ -259,11 +276,8 @@ var expressValidator = function(options) {
     req[validatorChainSymbol].push(options.customValidators);
 
     // Extend existing sanitizer. Fixes bug #341
-    if (req[sanitizerSymbol] && req[sanitizerSymbol] !== Sanitizer) {
-      Sanitizer = req[sanitizerSymbol];
-      utils.mapAndExtend(options.customSanitizers, Sanitizer.prototype, utils.makeSanitizer);
-    }
-    req[sanitizerSymbol] = Sanitizer;
+    req[sanitizerSymbol] = req[sanitizerSymbol] || [];
+    req[sanitizerSymbol].push(options.customSanitizers);
 
     req._validationErrors = [];
     req._asyncValidationErrors = [];

--- a/shared-typings.d.ts
+++ b/shared-typings.d.ts
@@ -107,6 +107,21 @@ export interface Validator {
   isDataURI(): this;
   isWhitelisted(chars: string | string[]): this;
 
+  // Sanitizers
+
+  blacklist(chars: string): this;
+  escape(): this;
+  unescape(): this;
+  normalizeEmail(options?: Options.NormalizeEmailOptions): this;
+  ltrim(chars?: string): this;
+  rtrim(chars?: string): this;
+  trim(chars?: string): this;
+  stripLow(keep_new_lines?: boolean): this;
+  toBoolean(strict?: boolean): this;
+  toDate(): this;
+  toFloat(): this;
+  toInt(radix?: number): this;
+  whitelist(chars: string): this;
 
   // Additional validators provided by validator.js
 

--- a/test/check.spec.js
+++ b/test/check.spec.js
@@ -118,4 +118,22 @@ describe('Legacy: req.check()/req.assert()/req.validate()', () => {
       expect(result.mapped()).to.have.property('foo.bar[0]');
     });
   });
+
+  it('chains standard/custom sanitizers', () => {
+    const req = {
+      params: { trimmed: ' foo  ' }
+    };
+
+    expressValidator({
+      customSanitizers: {
+        noFoo: value => value.replace('foo', '')
+      }
+    })(req, {}, () => {});
+    req.check('trimmed').trim().noFoo().notEmpty();
+
+    return req.getValidationResult().then(result => {
+      console.log(result.mapped());
+      expect(result.mapped()).to.have.property('trimmed');
+    });
+  });
 });

--- a/test/schema.spec.js
+++ b/test/schema.spec.js
@@ -98,6 +98,24 @@ describe('Legacy: Schema validation', () => {
     });
   });
 
+  it('applies sanitizers', () => {
+    const req = {
+      body: { trimmed: '  ' }
+    };
+
+    expressValidator()(req, {}, () => {});
+    req.check({
+      trimmed: {
+        trim: true,
+        notEmpty: true
+      }
+    });
+
+    return req.getValidationResult().then(result => {
+      expect(result.mapped()).to.have.property('trimmed');
+    });
+  });
+
   it('ignores validators which values are falsy', () => {
     const req = {
       body: {

--- a/test/type-definition.spec.ts
+++ b/test/type-definition.spec.ts
@@ -202,6 +202,36 @@ app.use((req: express.Request, res: express.Response, next: express.NextFunction
     .not()
     .exists()
     .optional().optional({ checkFalsy: true })
+    .trim()
+    .trim('abc')
+    .ltrim()
+    .ltrim('abc')
+    .rtrim()
+    .rtrim('abc')
+    .blacklist('a')
+    .whitelist('z')
+    .escape()
+    .unescape()
+    .toInt()
+    .toInt(10)
+    .toFloat()
+    .toDate()
+    .stripLow()
+    .stripLow(true)
+    .normalizeEmail()
+    .normalizeEmail({
+      all_lowercase: true,
+      gmail_lowercase: true,
+      gmail_remove_dots: true,
+      gmail_remove_subaddress: true,
+      gmail_convert_googlemaildotcom: true,
+      outlookdotcom_lowercase: true,
+      outlookdotcom_remove_subaddress: true,
+      yahoo_lowercase: true,
+      yahoo_remove_subaddress: true,
+      icloud_lowercase: true,
+      icloud_remove_subaddress: true
+    })
     .withMessage(new Error('message'))
     .withMessage(2)
     .withMessage('message');


### PR DESCRIPTION
Adds support for using validator sanitizers in the validation chain API.

Example:

```js
check('some.field').trim().escape().not().isEmpty();
```

Closes #417 