### PR TITLE
Filter API - Standalone Sanitization

### DIFF
--- a/check/check.js
+++ b/check/check.js
@@ -1,19 +1,7 @@
 const validator = require('validator');
 
 const runner = require('./runner');
-
-const extraValidators = ['contains', 'equals', 'matches'];
-const extraSanitizers = [
-  'blacklist',
-  'escape',
-  'unescape',
-  'normalizeEmail',
-  'ltrim',
-  'rtrim',
-  'trim',
-  'stripLow',
-  'whitelist'
-];
+const { extraSanitizers, extraValidators } = require('../utils/constants');
 
 module.exports = (fields, locations, message) => {
   let optional;

--- a/filter/index.d.ts
+++ b/filter/index.d.ts
@@ -1,7 +1,19 @@
 import * as express from 'express';
+import { Sanitizer } from '../shared-typings';
 
 export function matchedData (req: express.Request, options?: MatchedDataOptions): { [key: string]: any };
+export const sanitize: SanitizationChainBuilder;
+export const sanitizeBody: SanitizationChainBuilder;
+export const sanitizeCookie: SanitizationChainBuilder;
+export const sanitizeParam: SanitizationChainBuilder;
+export const sanitizeQuery: SanitizationChainBuilder;
 
 interface MatchedDataOptions {
   onlyValidData: boolean
 }
+
+export interface SanitizationChainBuilder {
+  (field: string | string[]): SanitizationChain;
+}
+
+export interface SanitizationChain extends express.RequestHandler, Sanitizer {}

--- a/filter/index.js
+++ b/filter/index.js
@@ -1,1 +1,6 @@
 exports.matchedData = require('./matched-data');
+exports.sanitize = require('./sanitize-all');
+exports.sanitizeBody = require('./sanitize-body');
+exports.sanitizeCookie = require('./sanitize-cookies');
+exports.sanitizeParam = require('./sanitize-params');
+exports.sanitizeQuery = require('./sanitize-query');

--- a/filter/sanitize-all.js
+++ b/filter/sanitize-all.js
@@ -1,0 +1,2 @@
+const sanitize = require('./sanitize');
+module.exports = fields => sanitize(fields, ['body', 'cookies', 'params', 'query']);

--- a/filter/sanitize-all.spec.js
+++ b/filter/sanitize-all.spec.js
@@ -1,0 +1,55 @@
+const expect = require('chai').expect;
+const sanitizeAll = require('./sanitize-all');
+
+describe('filter: sanitizeAll middleware', () => {
+  it('sanitizes body', () => {
+    const req = {
+      body: { foo: '123' }
+    };
+
+    sanitizeAll('foo').toInt()(req, {}, () => {});
+    expect(req.body.foo).to.equal(123);
+  });
+
+  it('sanitizes query', () => {
+    const req = {
+      query: { foo: '123' }
+    };
+
+    sanitizeAll('foo').toInt()(req, {}, () => {});
+    expect(req.query.foo).to.equal(123);
+  });
+
+  it('sanitizes params', () => {
+    const req = {
+      params: { foo: '123' }
+    };
+
+    sanitizeAll('foo').toInt()(req, {}, () => {});
+    expect(req.params.foo).to.equal(123);
+  });
+
+  it('sanitizes cookies', () => {
+    const req = {
+      cookies: { foo: '123' }
+    };
+
+    sanitizeAll('foo').toInt()(req, {}, () => {});
+    expect(req.cookies.foo).to.equal(123);
+  });
+
+  it('sanitizes all locations at the same time', () => {
+    const req = {
+      body: { foo: '123' },
+      cookies: { foo: '123' },
+      params: { foo: '123' },
+      query: { foo: '123' }
+    };
+
+    sanitizeAll('foo').toInt()(req, {}, () => {});
+    expect(req.body.foo).to.equal(123);
+    expect(req.cookies.foo).to.equal(123);
+    expect(req.query.foo).to.equal(123);
+    expect(req.params.foo).to.equal(123);
+  });
+});

--- a/filter/sanitize-body.js
+++ b/filter/sanitize-body.js
@@ -1,0 +1,2 @@
+const sanitize = require('./sanitize');
+module.exports = fields => sanitize(fields, ['body']);

--- a/filter/sanitize-body.spec.js
+++ b/filter/sanitize-body.spec.js
@@ -1,0 +1,13 @@
+const expect = require('chai').expect;
+const sanitizeBody = require('./sanitize-body');
+
+describe('filter: sanitizeBody middleware', () => {
+  it('sanitizes body', () => {
+    const req = {
+      body: { foo: '123' }
+    };
+
+    sanitizeBody('foo').toInt()(req, {}, () => {});
+    expect(req.body.foo).to.equal(123);
+  });
+});

--- a/filter/sanitize-cookies.js
+++ b/filter/sanitize-cookies.js
@@ -1,0 +1,2 @@
+const sanitize = require('./sanitize');
+module.exports = fields => sanitize(fields, ['cookies']);

--- a/filter/sanitize-cookies.spec.js
+++ b/filter/sanitize-cookies.spec.js
@@ -1,0 +1,13 @@
+const expect = require('chai').expect;
+const sanitizeCookies = require('./sanitize-cookies');
+
+describe('filter: sanitizeCookies middleware', () => {
+  it('sanitizes cookies', () => {
+    const req = {
+      cookies: { foo: '123' }
+    };
+
+    sanitizeCookies('foo').toInt()(req, {}, () => {});
+    expect(req.cookies.foo).to.equal(123);
+  });
+});

--- a/filter/sanitize-params.js
+++ b/filter/sanitize-params.js
@@ -1,0 +1,2 @@
+const sanitize = require('./sanitize');
+module.exports = fields => sanitize(fields, ['params']);

--- a/filter/sanitize-params.spec.js
+++ b/filter/sanitize-params.spec.js
@@ -1,0 +1,13 @@
+const expect = require('chai').expect;
+const sanitizeParams = require('./sanitize-params');
+
+describe('filter: sanitizeParams middleware', () => {
+  it('sanitizes params', () => {
+    const req = {
+      params: { foo: '123' }
+    };
+
+    sanitizeParams('foo').toInt()(req, {}, () => {});
+    expect(req.params.foo).to.equal(123);
+  });
+});

--- a/filter/sanitize-query.js
+++ b/filter/sanitize-query.js
@@ -1,0 +1,2 @@
+const sanitize = require('./sanitize');
+module.exports = fields => sanitize(fields, ['query']);

--- a/filter/sanitize-query.spec.js
+++ b/filter/sanitize-query.spec.js
@@ -1,0 +1,13 @@
+const expect = require('chai').expect;
+const sanitizeQuery = require('./sanitize-query');
+
+describe('filter: sanitizeQuery middleware', () => {
+  it('sanitizes query', () => {
+    const req = {
+      query: { foo: '123' }
+    };
+
+    sanitizeQuery('foo').toInt()(req, {}, () => {});
+    expect(req.query.foo).to.equal(123);
+  });
+});

--- a/filter/sanitize.js
+++ b/filter/sanitize.js
@@ -1,0 +1,34 @@
+const _ = require('lodash');
+const validator = require('validator');
+
+const { extraSanitizers } = require('../utils/constants');
+const selectFields = require('../check/select-fields');
+
+module.exports = (fields, locations) => {
+  const sanitizers = [];
+  fields = Array.isArray(fields) ? fields : [fields];
+
+  const middleware = (req, res, next) => {
+    const instances = selectFields(req, { fields, locations, sanitizers });
+    instances.forEach(instance => {
+      _.set(req[instance.location], instance.path, instance.value);
+    });
+
+    next();
+  };
+
+  Object.keys(validator)
+    .filter(methodName => methodName.startsWith('to') || extraSanitizers.includes(methodName))
+    .forEach(methodName => {
+      const sanitizerFn = validator[methodName];
+      middleware[methodName] = (...options) => {
+        sanitizers.push({
+          sanitizer: sanitizerFn,
+          options
+        });
+        return middleware;
+      };
+    });
+
+  return middleware;
+};

--- a/filter/sanitize.spec.js
+++ b/filter/sanitize.spec.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+const validator = require('validator');
+
+const sanitize = require('./sanitize');
+
+describe('filter: sanitize', () => {
+  it('returns chain with all validator\'s sanitization methods', () => {
+    const chain = sanitize();
+    Object.keys(validator)
+      .filter(methodName => methodName.startsWith('to'))
+      .forEach(methodName => {
+        expect(chain).to.have.property(methodName);
+      });
+
+    expect(chain).to.have.property('blacklist');
+    expect(chain).to.have.property('escape');
+    expect(chain).to.have.property('unescape');
+    expect(chain).to.have.property('normalizeEmail');
+    expect(chain).to.have.property('ltrim');
+    expect(chain).to.have.property('rtrim');
+    expect(chain).to.have.property('trim');
+    expect(chain).to.have.property('stripLow');
+    expect(chain).to.have.property('whitelist');
+  });
+
+  it('modifies each selected field in the request', () => {
+    const req = {
+      body: { foo: ' bar   ' },
+      query: { baz: '   qux' }
+    };
+
+    const chain = sanitize(['foo', 'baz'], ['body', 'query'])
+      .trim();
+
+    chain(req, {}, () => {});
+    expect(req.body.foo).to.equal('bar');
+    expect(req.query.baz).to.equal('qux');
+  });
+
+  it('calls the next() callback', () => {
+    let called = false;
+    const next = () => called = true;
+
+    sanitize('foo', ['body'])({}, {}, next);
+    expect(called).to.be.true;
+  });
+});

--- a/filter/type-definition.spec.ts
+++ b/filter/type-definition.spec.ts
@@ -1,7 +1,54 @@
-import { Request } from 'express';
-import { matchedData } from './';
+import { Request, Response } from 'express';
+import {
+  matchedData,
+  sanitize,
+  sanitizeBody,
+  sanitizeCookie,
+  sanitizeParam,
+  sanitizeQuery
+} from './';
 
 const req: Request = <Request>{};
+const res: Response = <Response>{};
 
 matchedData(req).foo;
 matchedData(req, { onlyValidData: true }).bar;
+
+// Sanitization
+sanitize('foo')(req, res, () => {});
+sanitizeBody('foo')(req, res, () => {});
+sanitizeCookie('foo')(req, res, () => {});
+sanitizeParam('foo')(req, res, () => {});
+sanitizeQuery('foo')(req, res, () => {});
+
+sanitize(['foo', 'bar'])
+  .trim()
+  .trim('abc')
+  .ltrim()
+  .ltrim('abc')
+  .rtrim()
+  .rtrim('abc')
+  .blacklist('a')
+  .whitelist('z')
+  .escape()
+  .unescape()
+  .toInt()
+  .toInt(10)
+  .toFloat()
+  .toDate()
+  .stripLow()
+  .stripLow(true)
+  .normalizeEmail()
+  .normalizeEmail({
+    all_lowercase: true,
+    gmail_lowercase: true,
+    gmail_remove_dots: true,
+    gmail_remove_subaddress: true,
+    gmail_convert_googlemaildotcom: true,
+    outlookdotcom_lowercase: true,
+    outlookdotcom_remove_subaddress: true,
+    yahoo_lowercase: true,
+    yahoo_remove_subaddress: true,
+    icloud_lowercase: true,
+    icloud_remove_subaddress: true
+  });

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ import {
   Result,
   MappedError,
   Options,
+  Sanitizer,
   Validator as BaseValidator
 } from './shared-typings';
 
@@ -106,52 +107,6 @@ declare namespace ExpressValidator {
 
     notEmpty(): this;
     len(options: Options.MinMaxOptions): this;
-  }
-
-  interface Sanitizer {
-    /**
-     * Convert the input string to a date, or null if the input is not a date.
-     */
-    toDate(): Sanitizer;
-    /**
-     * Convert the input string to a float, or NaN if the input is not a float.
-     */
-    toFloat(): Sanitizer;
-    /**
-     * Convert the input string to a float, or NaN if the input is not a float.
-     */
-    toInt(radix?: number): Sanitizer;
-    /**
-     * Cnvert the input string to a boolean.
-     * Everything except for '0', 'false' and '' returns true.
-     * @param strict If true, only '1' and 'true' return true.
-     */
-    toBoolean(strict?: boolean): Sanitizer;
-    /**
-     * Trim characters (whitespace by default) from both sides of the input.
-     * @param chars Defaults to whitespace
-     */
-    trim(chars?: string): Sanitizer;
-    ltrim(chars?: string): Sanitizer;
-    rtrim(chars?: string): Sanitizer;
-    /**
-     * Remove characters with a numerical value < 32 and 127, mostly control characters.
-     * Unicode-safe in JavaScript.
-     * @param keep_new_lines If true, newline characters are preserved (\n and \r, hex 0xA and 0xD).
-     */
-    stripLow(keep_new_lines?: boolean): Sanitizer;
-    /**
-     * Escape &, <, >, and "
-     */
-    escape(): Sanitizer;
-    /**
-     * Replaces HTML encoded entities with <, >, &, ', " and /.
-     */
-    unescape(): Sanitizer;
-    blacklist(chars: string): Sanitizer;
-    whitelist(chars: string): Sanitizer;
-
-    normalizeEmail(options?: Options.NormalizeEmailOptions): Sanitizer;
   }
 
 }

--- a/shared-typings.d.ts
+++ b/shared-typings.d.ts
@@ -9,7 +9,7 @@ export type Location = 'body' | 'params' | 'query' | 'headers' | 'cookie'
 
 export interface Dictionary<T> { [key: string]: T; }
 
-export interface Validator {
+export interface Validator extends Sanitizer {
 
   /*
     * Hi fellow contributor,
@@ -107,22 +107,6 @@ export interface Validator {
   isDataURI(): this;
   isWhitelisted(chars: string | string[]): this;
 
-  // Sanitizers
-
-  blacklist(chars: string): this;
-  escape(): this;
-  unescape(): this;
-  normalizeEmail(options?: Options.NormalizeEmailOptions): this;
-  ltrim(chars?: string): this;
-  rtrim(chars?: string): this;
-  trim(chars?: string): this;
-  stripLow(keep_new_lines?: boolean): this;
-  toBoolean(strict?: boolean): this;
-  toDate(): this;
-  toFloat(): this;
-  toInt(radix?: number): this;
-  whitelist(chars: string): this;
-
   // Additional validators provided by validator.js
 
   equals(equals: any): this;
@@ -136,6 +120,52 @@ export interface Validator {
   exists(): this;
   optional(options?: Options.OptionalOptions): this;
   withMessage(message: any): this;
+}
+
+interface Sanitizer {
+  /**
+   * Convert the input string to a date, or null if the input is not a date.
+   */
+  toDate(): this;
+  /**
+   * Convert the input string to a float, or NaN if the input is not a float.
+   */
+  toFloat(): this;
+  /**
+   * Convert the input string to a float, or NaN if the input is not a float.
+   */
+  toInt(radix?: number): this;
+  /**
+   * Cnvert the input string to a boolean.
+   * Everything except for '0', 'false' and '' returns true.
+   * @param strict If true, only '1' and 'true' return true.
+   */
+  toBoolean(strict?: boolean): this;
+  /**
+   * Trim characters (whitespace by default) from both sides of the input.
+   * @param chars Defaults to whitespace
+   */
+  trim(chars?: string): this;
+  ltrim(chars?: string): this;
+  rtrim(chars?: string): this;
+  /**
+   * Remove characters with a numerical value < 32 and 127, mostly control characters.
+   * Unicode-safe in JavaScript.
+   * @param keep_new_lines If true, newline characters are preserved (\n and \r, hex 0xA and 0xD).
+   */
+  stripLow(keep_new_lines?: boolean): this;
+  /**
+   * Escape &, <, >, and "
+   */
+  escape(): this;
+  /**
+   * Replaces HTML encoded entities with <, >, &, ', " and /.
+   */
+  unescape(): this;
+  blacklist(chars: string): this;
+  whitelist(chars: string): this;
+
+  normalizeEmail(options?: Options.NormalizeEmailOptions): this;
 }
 
 export interface MappedError {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,12 @@
+exports.extraValidators = ['contains', 'equals', 'matches'];
+exports.extraSanitizers = [
+  'blacklist',
+  'escape',
+  'unescape',
+  'normalizeEmail',
+  'ltrim',
+  'rtrim',
+  'trim',
+  'stripLow',
+  'whitelist'
+];


### PR DESCRIPTION
Follow up of #417/#418.
Adds standalone sanitization to the filter API:

```js
app.get('/', sanitize('email').normalizeEmail(), (req, res, next) => { ... });
```