### PR TITLE
Custom validator is missing in the typescript definition file

### DIFF
--- a/shared-typings.d.ts
+++ b/shared-typings.d.ts
@@ -114,6 +114,7 @@ export interface Validator extends Sanitizer {
   equals(equals: any): this;
   contains(str: string): this;
   matches(pattern: RegExp | string, modifiers?: string): this;
+  custom(callback: Function): this;
 
 
   // Additional ValidatorChain.prototype.* validators
@@ -295,6 +296,7 @@ declare namespace Options {
     equals?: ValidatorSchemaOptions
     contains?: ValidatorSchemaOptions
     matches?: ValidatorSchemaOptions
+    custom?: ValidatorSchemaOptions
   }
 
 


### PR DESCRIPTION
It was not possible to use the custom validator in a Typescript project, because the declaration for this validator was missing in the shared-typings.d.ts file. 