### PR TITLE
oneOf() with subgroups of validations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ indent_style = space
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
+end_of_line = lf
 
 [*.md]
 trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Same as `check(fields[, message])`, but only checking `req.params`.
 Same as `check(fields[, message])`, but only checking `req.query`.
 
 ### `oneOf(validationChains[, message])`
-- `validationChains`: an array of [validation chains](#validation-chain-api) created with `check()` or any of its variations.
+- `validationChains`: an array of [validation chains](#validation-chain-api) created with `check()` or any of its variations,
+  or an array of arrays containing validation chains.
 - `message` *(optional)*: an error message to use when all chains failed. Defaults to `Invalid value(s)`.
 > *Returns:* a middleware instance
 
@@ -146,6 +147,21 @@ app.post('/start-freelancing', oneOf([
     res.status(422).json(...);
   }
 });
+```
+
+If an item of the array is an array containing validation chains, then all of those must pass in order for this
+group be considered valid:
+
+```js
+// This protected route must be accessed either by passing both username + password,
+// or by passing an access token
+app.post('/protected/route', oneOf([
+  [
+    check('username').exists(),
+    check('password').exists()
+  ],
+  check('access_token').exists()
+]), someRouteHandler);
 ```
 
 The execution of those validation chains are made in parallel,

--- a/check/index.d.ts
+++ b/check/index.d.ts
@@ -1,6 +1,8 @@
 import * as express from 'express';
 import { Result, Options, Validator } from '../shared-typings';
 
+export type ValidationChains = ValidationChain | ValidationChain[];
+
 export const check: ValidationChainBuilder;
 export const body: ValidationChainBuilder;
 export const cookie: ValidationChainBuilder;
@@ -8,7 +10,7 @@ export const header: ValidationChainBuilder;
 export const param: ValidationChainBuilder;
 export const query: ValidationChainBuilder;
 export function validationResult (req: express.Request): Result;
-export function oneOf (chains: ValidationChain[]): express.RequestHandler;
+export function oneOf (chains: ValidationChains[], message?: string): express.RequestHandler;
 
 export interface ValidationChainBuilder {
   (field: string | string[], message?: string): ValidationChain;

--- a/check/one-of.spec.js
+++ b/check/one-of.spec.js
@@ -22,6 +22,38 @@ describe('check: checkOneOf middleware', () => {
     });
   });
 
+  it('groups arrays of chains', () => {
+    const req = {
+      cookies: { foo: 'abc', bar: 'def', baz: 123 }
+    };
+
+    return oneOf([
+      [ check('foo').isInt(), check('bar').isInt() ],
+      check('baz').isAlpha()
+    ])(req, {}, () => {}).then(errors => {
+      expect(errors[0]).to.eql([{
+        location: 'cookies',
+        param: 'foo',
+        value: 'abc',
+        msg: 'Invalid value'
+      }, {
+        location: 'cookies',
+        param: 'bar',
+        value: 'def',
+        msg: 'Invalid value'
+      }]);
+
+      expect(errors[1]).to.eql([{
+        location: 'cookies',
+        param: 'baz',
+        value: 123,
+        msg: 'Invalid value'
+      }]);
+
+      expect(req._validationErrors[0].nestedErrors).to.have.lengthOf(3);
+    });
+  });
+
   describe('error message', () => {
     it('is "Invalid value(s)" by default', done => {
       const req = {

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -47,8 +47,10 @@ check('foo')(req, res, () => {});
 
 oneOf([
   check('foo').isInt(),
-  check('bar').isDecimal()
+  [ check('bar').isDecimal(), check('baz').isHexColor() ]
 ])(req, res, () => {});
+
+oneOf([ check('foo').isInt(), check('bar').isDecimal() ], 'some message');
 
 // Test validation chain methods
 check('foo', 'with error message')


### PR DESCRIPTION
Adds support for passing groups of validations that must pass together to `oneOf()`:

```js
// This protected route must be accessed either by passing both username + password,
// or by passing an access token
app.post('/protected/route', oneOf([
  [
    check('username').exists(),
    check('password').exists()
  ],
  check('access_token').exists()
]), someRouteHandler);
```

Closes #434 
