### PR TITLE
check: support default options for validationResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ try {
 
 ### `.withDefaults(options)`
 - `options` *(optional)*: an object of options. Defaults to `{ formatter: error => error }`
-> *Returns:* a new validation result instance with provided default options
+> *Returns:* a new [validationResult](#validationresultreq) function is returned, using the provided options
 
 This is useful when you have a consistent set of options you would like to use for all validation results throughout your application.
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,28 @@ try {
 }
 ```
 
+### `.withDefaults(options)`
+- `options` *(optional)*: an object of options. Defaults to `{ formatter: error => error }`
+> *Returns:* a new validation result instance with provided default options
+
+This is useful when you have a consistent set of options you would like to use for all validation results throughout your application.
+
+Below is an example which sets a default error formatter:
+
+```
+const { validationResult } = require('express-validator/check');
+
+const result = validationResult.withDefaults({
+    formatter: (error) => {
+        return {
+            myLocation: error.location,
+        };
+    }
+});
+
+module.exports = result;
+```
+
 ---
 
 ## Legacy API

--- a/check/index.d.ts
+++ b/check/index.d.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { Result, Options, Validator } from '../shared-typings';
+import { Validator } from '../shared-typings';
 
 export type ValidationChains = ValidationChain | ValidationChain[];
 
@@ -9,7 +9,7 @@ export const cookie: ValidationChainBuilder;
 export const header: ValidationChainBuilder;
 export const param: ValidationChainBuilder;
 export const query: ValidationChainBuilder;
-export function validationResult (req: express.Request): Result;
+export { default as validationResult } from './validation-result';
 export function oneOf (chains: ValidationChains[], message?: string): express.RequestHandler;
 
 export interface ValidationChainBuilder {

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -9,7 +9,6 @@ import {
   oneOf,
   validationResult
 } from './'
-import { withDefaults } from './validation-result'
 
 const req: Request = <Request>{};
 const res: Response = <Response>{};
@@ -24,7 +23,7 @@ result.formatWith(error => {
   error.value;
 });
 
-withDefaults({
+const resultWithDefaults: validationResult = validationResult.withDefaults({
   formatter: error => {
     error.msg;
     error.location;
@@ -32,6 +31,7 @@ withDefaults({
     error.value;
   }
 });
+resultWithDefaults(req);
 
 const arrayErrors = result.array();
 arrayErrors[0].location;

--- a/check/type-definition.spec.ts
+++ b/check/type-definition.spec.ts
@@ -9,6 +9,7 @@ import {
   oneOf,
   validationResult
 } from './'
+import { withDefaults } from './validation-result'
 
 const req: Request = <Request>{};
 const res: Response = <Response>{};
@@ -21,6 +22,15 @@ result.formatWith(error => {
   error.location;
   error.param;
   error.value;
+});
+
+withDefaults({
+  formatter: error => {
+    error.msg;
+    error.location;
+    error.param;
+    error.value;
+  }
 });
 
 const arrayErrors = result.array();

--- a/check/validation-result.d.ts
+++ b/check/validation-result.d.ts
@@ -1,7 +1,15 @@
-import { ErrorFormatter } from '../shared-typings';
+import * as express from 'express';
+import { Result, ErrorFormatter } from '../shared-typings';
 
-export function withDefaults(options: WithDefaultsOptions) : object;
+export const validationResult: validationResult;
+
+export interface validationResult {
+  (req: express.Request): Result;
+  withDefaults(options: WithDefaultsOptions) : this;
+}
 
 interface WithDefaultsOptions {
-  formatter: ErrorFormatter
+  formatter: ErrorFormatter;
 }
+
+export default validationResult;

--- a/check/validation-result.d.ts
+++ b/check/validation-result.d.ts
@@ -1,0 +1,7 @@
+import { ErrorFormatter } from '../shared-typings';
+
+export function withDefaults(options: WithDefaultsOptions) : object;
+
+interface WithDefaultsOptions {
+  formatter: ErrorFormatter
+}

--- a/check/validation-result.js
+++ b/check/validation-result.js
@@ -1,41 +1,54 @@
-module.exports = req => decorateAsValidationResult({}, req._validationErrors);
+const _ = require('lodash');
 
-function decorateAsValidationResult(obj, errors = []) {
-  let formatter = error => error;
+module.exports = withDefaults();
+module.exports.withDefaults = withDefaults;
 
-  obj.isEmpty = () => !errors.length;
-  obj.array = ({ onlyFirstError } = {}) => {
-    const used = {};
-    let filteredErrors = !onlyFirstError ? errors : errors.filter(error => {
-      if (used[error.param]) {
-        return false;
+function withDefaults(options = {}) {
+  const defaults = {
+    formatter: error => error
+  };
+
+  _.defaults(options, defaults);
+
+  function decorateAsValidationResult(obj, errors = []) {
+    let formatter = options.formatter;
+
+    obj.isEmpty = () => !errors.length;
+    obj.array = ({ onlyFirstError } = {}) => {
+      const used = {};
+      let filteredErrors = !onlyFirstError ? errors : errors.filter(error => {
+        if (used[error.param]) {
+          return false;
+        }
+
+        used[error.param] = true;
+        return true;
+      });
+
+      return filteredErrors.map(formatter);
+    };
+
+    obj.mapped = () => errors.reduce((mapping, error) => {
+      if (!mapping[error.param]) {
+        mapping[error.param] = formatter(error);
       }
 
-      used[error.param] = true;
-      return true;
-    });
+      return mapping;
+    }, {});
 
-    return filteredErrors.map(formatter);
-  };
+    obj.formatWith = errorFormatter => {
+      formatter = errorFormatter;
+      return obj;
+    };
 
-  obj.mapped = () => errors.reduce((mapping, error) => {
-    if (!mapping[error.param]) {
-      mapping[error.param] = formatter(error);
-    }
+    obj.throw = () => {
+      if (errors.length) {
+        throw decorateAsValidationResult(new Error('Validation failed'), errors).formatWith(formatter);
+      }
+    };
 
-    return mapping;
-  }, {});
-
-  obj.formatWith = errorFormatter => {
-    formatter = errorFormatter;
     return obj;
-  };
+  }
 
-  obj.throw = () => {
-    if (errors.length) {
-      throw decorateAsValidationResult(new Error('Validation failed'), errors).formatWith(formatter);
-    }
-  };
-
-  return obj;
+  return req => decorateAsValidationResult({}, req._validationErrors)
 }

--- a/check/validation-result.spec.js
+++ b/check/validation-result.spec.js
@@ -64,6 +64,44 @@ describe('check: validationResult', () => {
       expect(errors[0]).to.have.property('code', 'foo');
       expect(errors[1]).to.have.property('code', 'foo');
     });
+
+    it('formats using formatter passed via .withDefaults()', () => {
+      const resultWithDefaults = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'foo' }, error);
+        }
+      });
+      const result = resultWithDefaults({ _validationErrors: allErrors });
+
+      let errors = result.array();
+      expect(errors[0]).to.have.property('code', 'foo');
+      expect(errors[1]).to.have.property('code', 'foo');
+      expect(errors[2]).to.have.property('code', 'foo');
+
+      errors = result.array({ onlyFirstError: true });
+      expect(errors[0]).to.have.property('code', 'foo');
+      expect(errors[1]).to.have.property('code', 'foo');
+    });
+
+    it('formats using formatter passed via .formatWith(), although a formatter passed via .withDefaults() is set', () => {
+      const resultWithDefaults = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'bar' }, error);
+        }
+      });
+      const result = resultWithDefaults({ _validationErrors: allErrors }).formatWith(error => {
+        return Object.assign({ code: 'foo' }, error);
+      });;
+
+      let errors = result.array();
+      expect(errors[0]).to.have.property('code', 'foo');
+      expect(errors[1]).to.have.property('code', 'foo');
+      expect(errors[2]).to.have.property('code', 'foo');
+
+      errors = result.array({ onlyFirstError: true });
+      expect(errors[0]).to.have.property('code', 'foo');
+      expect(errors[1]).to.have.property('code', 'foo');
+    });
   });
 
   describe('.mapped()', () => {
@@ -77,6 +115,34 @@ describe('check: validationResult', () => {
 
     it('formats using formatter passed via .formatWith()', () => {
       const result = validationResult({ _validationErrors: allErrors }).formatWith(error => {
+        return Object.assign({ code: 'bar' }, error);
+      });
+
+      expect(result.mapped()).to.eql({
+        foo: { param: 'foo', msg: 'blabla', code: 'bar' },
+        bar: { param: 'bar', msg: 'yay', code: 'bar' }
+      });
+    });
+
+    it('formats using formatter passed via .withDefaults()', () => {
+      const resultWithDefaults = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'bar' }, error);
+        }
+      });
+      const result = resultWithDefaults({ _validationErrors: allErrors });
+
+      expect(result.mapped()).to.eql({
+        foo: { param: 'foo', msg: 'blabla', code: 'bar' },
+        bar: { param: 'bar', msg: 'yay', code: 'bar' }
+      });
+    });
+
+    it('formats using formatter passed via .formatWith(), although a formatter passed via .withDefaults() is set', () => {
+      const resultWithDefaults = validationResult.withDefaults(error => {
+        return Object.assign({ code: 'baz' }, error);
+      });
+      const result = resultWithDefaults({ _validationErrors: allErrors }).formatWith(error => {
         return Object.assign({ code: 'bar' }, error);
       });
 
@@ -124,6 +190,80 @@ describe('check: validationResult', () => {
         expect(e.array()).to.have.deep.property('[0].code', 'foo');
         done();
       }
+    });
+
+    it('passes formatter passed via .withDefaults()', done => {
+      const resultWithDefaults = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'foo' }, error);
+        }
+      });
+      const result = resultWithDefaults({ _validationErrors: allErrors });
+
+      try {
+        result.throw();
+        done(new Error('no errors thrown'));
+      } catch (e) {
+        expect(e.array()).to.have.deep.property('[0].code', 'foo');
+        done();
+      }
+    });
+
+    it('passes formatter passed via .formatWith(), athough a formatter passed via .withDefaults() is set', done => {
+      const resultWithDefaults = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'bar' }, error);
+        }
+      });
+      const result = resultWithDefaults({ _validationErrors: allErrors }).formatWith(error => {
+        return Object.assign({ code: 'foo' }, error);
+      });
+
+      try {
+        result.throw();
+        done(new Error('no errors thrown'));
+      } catch (e) {
+        expect(e.array()).to.have.deep.property('[0].code', 'foo');
+        done();
+      }
+    });
+  });
+
+  describe('.withDefaults()', () => {
+    it('uses default formatter if options are not supplied', () => {
+      const resultWithDefaults = validationResult.withDefaults();
+      const result = resultWithDefaults({ _validationErrors: allErrors });
+
+      expect(result.mapped()).to.eql({
+        foo: { param: 'foo', msg: 'blabla' },
+        bar: { param: 'bar', msg: 'yay' }
+      });
+    });
+
+    it('creates a separate validationResult instance', () => {
+      const resultWithDefaults1 = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'bar' }, error);
+        }
+      });
+      const result1 = resultWithDefaults1({ _validationErrors: allErrors });
+
+      const resultWithDefaults2 = validationResult.withDefaults({
+        formatter: error => {
+          return Object.assign({ code: 'baz' }, error);
+        }
+      });
+      const result2 = resultWithDefaults2({ _validationErrors: allErrors });
+
+      expect(result1.mapped()).to.eql({
+        foo: { param: 'foo', msg: 'blabla', code: 'bar' },
+        bar: { param: 'bar', msg: 'yay', code: 'bar' }
+      });
+
+      expect(result2.mapped()).to.eql({
+        foo: { param: 'foo', msg: 'blabla', code: 'baz' },
+        bar: { param: 'bar', msg: 'yay', code: 'baz' }
+      });
     });
   });
 });


### PR DESCRIPTION
This is a proposal to resolve https://github.com/ctavan/express-validator/issues/427, by introducing a way to set default options for the `validation-result` module

It introduces a new `.withDefaults` function, which will return a new instance of the module with specified default options. The decision to return a new instance was to avoid affecting the global module state in the case that multiple `validationResult` implementations are desired within the same application.

This is loosely inspired on the concept of `request.defaults` from the [request/request](https://github.com/request/request#requestdefaultsoptions) module

Here's a brief example:
```
// baseValidationResult.js ----
const { validationResult } = require('express-validator/check');

const result = validationResult.withDefaults({
    formatter: (error) => {
        return {
            myLocation: error.location,
        };
    }
});

module.exports = result;

// within an express router ----
const validationResult = require('./baseValidationResult');

errors = validationResult(req);

if (!errors.isEmpty()) {
  return res.status(422).json({
    errors: errors.mapped(),
  });
}
```

Note: This is my first time getting acquainted with TypeScript, so let me know if the definitions make sense