### PR TITLE
fix issue where undefined nested properties under a wildcard are not validated

### DIFF
--- a/check/select-fields.js
+++ b/check/select-fields.js
@@ -13,7 +13,7 @@ module.exports = (req, context) => {
       .filter(optionalityFilter)
       .value();
 
-    if (instances.length > 1) {
+    if (instances.length > 1 && context.locations.length > 1) {
       const withValue = instances.filter(field => field.value !== undefined);
       instances = withValue.length ? withValue : [instances[0]];
     }

--- a/check/select-fields.spec.js
+++ b/check/select-fields.spec.js
@@ -68,6 +68,29 @@ describe('check: field selection', () => {
     });
   });
 
+  it('is done in nested wildcard locations with `undefined` values for validation', () => {
+    const req = {
+      body: { foo: [{}, { bar: 'a'}] }
+    };
+
+    const instances = selectFields(req, {
+      fields: ['foo.*.bar'],
+      locations: ['body']
+    });
+
+    expect(instances).to.have.length(2);
+    expect(instances).to.deep.include({
+      path: 'foo[0].bar',
+      location: 'body',
+      value: undefined
+    });
+    expect(instances).to.deep.include({
+      path: 'foo[1].bar',
+      location: 'body',
+      value: 'a'
+    });
+  });
+
   it('expands "*" wildcards shallowly', () => {
     const req = {
       body: {


### PR DESCRIPTION
this partially fixes the #458. as long as you specify where in the request to look for the field, instead of using the catch-call `check()` (ie, `param()`, `query()`, etc.), this fixes the issue.

it's only a partial fix, but it is a simple change and this at least makes it possible to do this kind of validation (ie checking for `undefined`'s)