### PR TITLE
Proof of concept: break validation chain early.

### DIFF
--- a/check/check-body.js
+++ b/check/check-body.js
@@ -1,2 +1,2 @@
 const check = require('./check');
-module.exports = (fields, message) => check(fields, ['body'], message);
+module.exports = (fields, message, opts) => check(fields, ['body'], message, opts);

--- a/check/check.js
+++ b/check/check.js
@@ -3,7 +3,7 @@ const validator = require('validator');
 const runner = require('./runner');
 const { extraSanitizers, extraValidators } = require('../utils/constants');
 
-module.exports = (fields, locations, message) => {
+module.exports = (fields, locations, message, opts) => {
   let optional;
   const validators = [];
   const sanitizers = [];
@@ -86,7 +86,8 @@ module.exports = (fields, locations, message) => {
     fields,
     locations,
     sanitizers,
-    validators
+    validators,
+    opts: opts || {}
   };
 
   return middleware;

--- a/check/runner.js
+++ b/check/runner.js
@@ -6,6 +6,8 @@ module.exports = (req, context) => {
   const promises = selectFields(req, context).map(field => {
     const { location, path, value } = field;
     return context.validators.reduce((promise, validatorCfg) => promise.then(() => {
+      if (context.opts.break_chain_on_failure && validationErrors.length) { return promise; }
+
       const result = validatorCfg.custom ?
         validatorCfg.validator(value, { req, location, path }) :
         validatorCfg.validator(toString(value), ...validatorCfg.options);


### PR DESCRIPTION
This is a brief proof of concept PR to demonstrate returning early from a validation chain when a single validator fails. Sometimes you only want to call into a complex (expensive) business logic validator if simpler validators have already passed.

Best explained by an example:
```
body('submitted_id', null, {break_chain_on_failure: true})
  .trim()
  .isUuid()
  .custom(value => someExpensiveDBCall(value))
  .custom(value => someExpensiveNetworkCall(value))
```
For example, this will fail with a single UUID validator error if the submitted value is not a UUID. It will not attempt any of the further logic tests. If the UUID check succeeds but the DB check fails, the network check will not be performed.

Any thoughts on the idea? It doesn't introduce obvious breaking changes but I haven't put a lot of thought into edge cases.

I'm also relatively new to express-validator so maybe there is a way to accomplish the same thing nicely that I have overlooked?