### PR TITLE
Fix missing values from matchedData when using arrays in oneOf

### DIFF
--- a/check/one-of.js
+++ b/check/one-of.js
@@ -8,18 +8,24 @@ module.exports = (validationChains, message) => (req, res, next) => {
     return Array.isArray(chain) ? chain.map(getContext) : getContext(chain);
   });
 
+  // These promises resolve to an array with results with the chain that
+  // generated the results
   const promises = validationChains.map(chain => {
     if (!Array.isArray(chain)) {
-      return run(chain);
+      return run(chain).then(results => [results, chain]);
     }
 
-    return Promise.all(chain.map(run)).then(results => _.flatten(results, true));
+    return Promise.all(chain.map(run)).then(results => [_.flatten(results, true), chain]);
   });
 
-  return Promise.all(promises).then(results => {
+  return Promise.all(promises).then(resultsAndChains => {
+    const [results, successFields] = extractResultsAndSuccessFields(resultsAndChains);
+
     req._validationContexts = (req._validationContexts || []).concat(contexts);
     req._validationErrors = req._validationErrors || [];
-    req._validationErrorsOneOf = _.flatten(results);
+    req._validationErrorsOneOf = _.flatten(results)
+      // Remove error results that matches fields in the successful chain
+      .filter(result => !successFields.includes(result.param));
 
     const empty = results.some(result => result.length === 0);
     if (!empty) {
@@ -34,6 +40,16 @@ module.exports = (validationChains, message) => (req, res, next) => {
     return results;
   }).catch(next);
 };
+
+function extractResultsAndSuccessFields(resultsAndChains) {
+  const results = resultsAndChains.map(([r]) => r);
+  const successIndex = results.findIndex(res => res.length === 0);
+  const successChain = successIndex >= 0 ? resultsAndChains[successIndex][1] : [];
+  const successFields = (Array.isArray(successChain)
+    ? _.flatten(successChain.map(getContext).map(c => c.fields))
+    : getContext(successChain).fields);
+  return [results, successFields];
+}
 
 function getContext(chain) {
   return chain._context;

--- a/filter/matched-data.spec.js
+++ b/filter/matched-data.spec.js
@@ -45,6 +45,26 @@ describe('filter: matchedData', () => {
     });
   });
 
+  it('includes data only from the successful chain in oneOfs with nested chains', () => {
+    const req = {
+      headers: { foo: 'foo', bar: '123', baz: 'baz' }
+    };
+
+    return oneOf([
+      [
+        check('foo').not().exists(),
+        check('bar').not().isInt()
+      ],
+      [
+        check('foo').exists(),
+        check('bar').isInt()
+      ]
+    ])(req, {}, () => {}).then(() => {
+      const data = matchedData(req);
+      expect(data).to.eql({ foo: 'foo', bar: '123' });
+    });
+  });
+
   describe('when option onlyValidData is set to false', () => {
     it('returns object with all data validated in the request', () => {
       const req = {


### PR DESCRIPTION
Fixes #533.

If `oneOf` has a successful chain then any error that match the first successful chain's fields is filtered out of `req._validationErrorsOneOf` so that `matchedData` won't exclude it.