### PR TITLE
Added SanitizersSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,40 @@ app.put('/user/:id/password', checkSchema({
     // Sanitizers can go here as well
     toInt: true
   },
+  myCustomField: {
+    // Custom validators
+    custom: {
+      options: (value, { req, location, path }) => {
+        return value + req.body.foo + location + path;
+      }
+    },
+    // and sanitizers
+    customSanitizer: {
+      options: (value, { req, location, path }) => {
+        let sanitizedValue;
+
+        if (req.body.foo && location && path) {
+          sanitizedValue = parseInt(value);
+        } else {
+          sanitizedValue = 0;
+        }
+
+        return sanitizedValue;
+      }
+    },
+  },
   password: {
     isLength: {
       errorMessage: 'Password should be at least 7 chars long',
       // Multiple options would be expressed as an array
       options: { min: 7 }
     }
+  },
+  firstName: {
+    rtrim: {
+      // Options as an array
+        options: [[" ", "-"]],
+    },
   },
   // Wildcards/dots for nested fields work as well
   'addresses.*.postalCode': {

--- a/check/schema.d.ts
+++ b/check/schema.d.ts
@@ -1,5 +1,6 @@
 import { ValidationChain, ValidatorOptions, CustomValidator } from './check';
 import { Location } from './location';
+import { CustomSanitizer } from '../filter/sanitize';
 
 export function checkSchema(schema: ValidationSchema): ValidationChain[];
 
@@ -21,6 +22,8 @@ interface ValidationParamSchema extends ValidatorsSchema, SanitizersSchema {
   custom?: ValidatorSchemaOptions<CustomValidator>;
   exists?: ValidatorSchemaOptions;
   optional?: boolean | ValidatorOptions.OptionalOptions;
+
+  customSanitizer?: SanitizerSchemaOptions<CustomSanitizer>;
 }
 
 interface ValidatorsSchema {

--- a/check/schema.d.ts
+++ b/check/schema.d.ts
@@ -10,16 +10,22 @@ type ValidatorSchemaOptions<T = any> = true | {
   errorMessage?: any;
 };
 
-interface ValidationParamSchema {
+type SanitizerSchemaOptions<T = any> = true | {
+  options?: T | T[];
+};
+
+interface ValidationParamSchema extends ValidatorsSchema, SanitizersSchema {
   in: Location | Location[],
   errorMessage?: any
 
   custom?: ValidatorSchemaOptions<CustomValidator>;
   exists?: ValidatorSchemaOptions;
   optional?: boolean | ValidatorOptions.OptionalOptions;
+}
 
-  equals?: ValidatorSchemaOptions;
+interface ValidatorsSchema {
   contains?: ValidatorSchemaOptions;
+  equals?: ValidatorSchemaOptions;
   isAfter?: ValidatorSchemaOptions;
   isAlpha?: ValidatorSchemaOptions;
   isAlphanumeric?: ValidatorSchemaOptions;
@@ -72,4 +78,20 @@ interface ValidationParamSchema {
   isVariableWidth?: ValidatorSchemaOptions;
   isWhitelisted?: ValidatorSchemaOptions;
   matches?: ValidatorSchemaOptions;
+}
+
+interface SanitizersSchema {
+  blacklist?: SanitizerSchemaOptions;
+  escape?: true;
+  unescape?: true;
+  ltrim?: true | SanitizerSchemaOptions;
+  normalizeEmail?: true | SanitizerSchemaOptions;
+  rtrim?: true | SanitizerSchemaOptions;
+  stripLow?: true | SanitizerSchemaOptions;
+  toBoolean?: true | SanitizerSchemaOptions;
+  toDate?: true;
+  toFloat?: true;
+  toInt?: true | SanitizerSchemaOptions;
+  trim?: true | SanitizerSchemaOptions;
+  whitelist?: true | SanitizerSchemaOptions;
 }

--- a/check/schema.spec.ts
+++ b/check/schema.spec.ts
@@ -8,9 +8,26 @@ const fooSchema: ValidationParamSchema = {
     errorMessage: 'foo',
     options: [['foo', 'bar']]
   },
+  toInt: true,
+  toBoolean: {
+    options: true // Strict mode
+  },
   custom: {
     options: (value, { req, location, path }) => {
       return value + req.body.foo + location + path;
+    }
+  },
+  customSanitizer: {
+    options: (value, { req, location, path }) => {
+      let sanitizedValue;
+
+      if (req.body.foo && location && path) {
+        sanitizedValue = parseInt(value);
+      } else {
+        sanitizedValue = 0;
+      }
+
+      return sanitizedValue;
     }
   },
   exists: true


### PR DESCRIPTION
This PR adds a Sanitizer schema when using the function `checkSchema`. 

Sanitizers like `toInt`, `escape` and so on now appears in the intellisense section and Typescript yields no more.

If something is missing please let me now.

