### PR TITLE
Sanitization fixes

### DIFF
--- a/check/runner.js
+++ b/check/runner.js
@@ -3,7 +3,7 @@ const selectFields = require('../utils/select-fields');
 
 module.exports = (req, context) => {
   const validationErrors = [];
-  const promises = selectFields(req, context, false).map(field => {
+  const promises = selectFields(req, context, { sanitizeFields: false }).map(field => {
     const { location, path, value } = field;
     return context.validators.reduce((promise, validatorCfg) => promise.then(() => {
       const result = validatorCfg.custom ?

--- a/check/runner.js
+++ b/check/runner.js
@@ -3,7 +3,7 @@ const selectFields = require('../utils/select-fields');
 
 module.exports = (req, context) => {
   const validationErrors = [];
-  const promises = selectFields(req, context).map(field => {
+  const promises = selectFields(req, context, false).map(field => {
     const { location, path, value } = field;
     return context.validators.reduce((promise, validatorCfg) => promise.then(() => {
       const result = validatorCfg.custom ?

--- a/check/schema.js
+++ b/check/schema.js
@@ -30,7 +30,7 @@ module.exports = (
       }
 
       chain[method](...options);
-      if (method !== 'optional') {
+      if (method !== 'optional' && methodCfg.errorMessage) {
         chain.withMessage(methodCfg.errorMessage);
       }
     });

--- a/utils/select-fields.js
+++ b/utils/select-fields.js
@@ -1,10 +1,13 @@
 const _ = require('lodash');
 const formatParamOutput = require('./format-param-output');
 
-module.exports = (req, context, sanitizeFields = true) => {
+module.exports = (req, context, config) => {
+  const defaults = { sanitizeFields: true };
+  config = Object.assign({}, defaults, config);
+
   let allFields = [];
   const optionalityFilter = createOptionalityFilter(context);
-  const sanitizerMapper = sanitizeFields ? createSanitizerMapper(req, context) : e => e;
+  const sanitizerMapper = config.sanitizeFields ? createSanitizerMapper(req, context) : e => e;
 
   context.fields.forEach(field => {
     let instances = _(context.locations)

--- a/utils/select-fields.js
+++ b/utils/select-fields.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
 const formatParamOutput = require('./format-param-output');
 
-module.exports = (req, context) => {
+module.exports = (req, context, sanitizeFields = true) => {
   let allFields = [];
   const optionalityFilter = createOptionalityFilter(context);
-  const sanitizerMapper = createSanitizerMapper(req, context);
+  const sanitizerMapper = sanitizeFields ? createSanitizerMapper(req, context) : e => e;
 
   context.fields.forEach(field => {
     let instances = _(context.locations)


### PR DESCRIPTION
+ Now the sanitizers run after validations
+ The error summary is no longer touched by sanitizers (for better explanation when a validation fails)

For this schema

``` js
{
    id: {
        in: ["params"],
        isNumeric: { errorMessage: "The 'id' param must be a number" },
        toInt: true,
    },
}
```
When `id` is not numeric, the sanitizer produced this:

``` js
{
    "id": {
        "location": "params",
        "param": "id",
        "value": NaN,
        "msg": "Invalid value"
    }
}
```

And turning this into JSON produced:

``` js
{
    "id": {
        "location": "params",
        "param": "id",
        "value": null,
        "msg": "Invalid value"
    }
}
```

With this PR the error summary `.mapped()` remains untouched, however in the `request` object these values remain been sanitized (that is the goal of the library).

+ When using schema, sanitizers no longer overrides errorMessage from validations.

Using the same schema above, `msg` said `Invalid value` while there is a `errorMessage` set:

``` js
isNumeric: { errorMessage: "The 'id' param must be a number" }
```

This PR preserves the errorMessage.

Additional notes:

If only sanitizers are provided, if `id` is not an int then `req.params.id` will be `NaN`. 

``` js
{
    id: {
        in: ["params"],
        toInt: true,
    },
}
```