### PR TITLE
Avoid double sanitization when using matchedData()

### DIFF
--- a/filter/matched-data.js
+++ b/filter/matched-data.js
@@ -16,7 +16,10 @@ module.exports = (req, options = {}) => {
 };
 
 function createFieldExtractor(req) {
-  return context => [].concat(selectFields(req, context)).map(instance => ({
+  return context => [].concat(selectFields(req, context, {
+    // By the time we get here, all sanitizers did run, so we don't want double sanitization.
+    sanitize: false
+  })).map(instance => ({
     instance,
     context
   }));

--- a/filter/matched-data.spec.js
+++ b/filter/matched-data.spec.js
@@ -31,6 +31,17 @@ describe('filter: matchedData', () => {
     });
   });
 
+  it('does not double sanitize data', () => {
+    const req = {
+      body: { text: '<tag>' }
+    };
+
+    return check('text').escape()(req, {}, () => {}).then(() => {
+      const data = matchedData(req);
+      expect(data).to.eql({ text: '&lt;tag&gt;' });
+    });
+  });
+
   describe('with oneOf()', () => {
     it('includes data only from the successful chains by default', () => {
       const req = {

--- a/utils/select-fields.js
+++ b/utils/select-fields.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
 const formatParamOutput = require('./format-param-output');
 
-module.exports = (req, context) => {
+module.exports = (req, context, options = {}) => {
   let allFields = [];
   const optionalityFilter = createOptionalityFilter(context);
-  const sanitizerMapper = createSanitizerMapper(req, context);
+  const sanitizerMapper = createSanitizerMapper(req, context, options);
 
   context.fields.map(field => field == null ? '' : field).forEach(field => {
     let instances = _(context.locations)
@@ -60,8 +60,8 @@ function expand(object, path, paths) {
   return paths;
 }
 
-function createSanitizerMapper(req, { sanitizers = [] }) {
-  return field => sanitizers.reduce((prev, sanitizer) => {
+function createSanitizerMapper(req, { sanitizers = [] }, { sanitize = true }) {
+  return !sanitize ? field => field : field => sanitizers.reduce((prev, sanitizer) => {
     const value = typeof prev.value === 'string' ?
       callSanitizer(sanitizer, prev) :
       prev.value;

--- a/utils/select-fields.spec.js
+++ b/utils/select-fields.spec.js
@@ -248,6 +248,25 @@ describe('utils: selectFields', () => {
         path: 'id'
       });
     });
+
+    it('does not run if options.sanitize is false', () => {
+      const req = {
+        body: { text: 'bla' }
+      };
+
+      const instances = selectFields(req, {
+        locations: ['body'],
+        fields: ['text'],
+        sanitizers: [{
+          options: [],
+          sanitizer: value => value + 'bla'
+        }]
+      }, {
+        sanitize: false
+      });
+
+      expect(instances[0].value).to.equal('bla');
+    });
   });
 
   describe('optional context', () => {


### PR DESCRIPTION
Fixes #554