### PR TITLE
Convert date to ISO string before validating it

### DIFF
--- a/check/runner.spec.js
+++ b/check/runner.spec.js
@@ -359,6 +359,23 @@ describe('check: context runner', () => {
       });
     });
 
+    it('receive ISO representation when Date', () => {
+      const req = {
+        headers: { bestdate: new Date(Date.UTC(2012, 11, 12)) }
+      };
+
+      return runner(req, {
+        locations: ['headers'],
+        fields: ['bestdate'],
+        validators: [{
+          options: [],
+          validator: value => Promise.reject(value)
+        }]
+      }).then(errors => {
+        expect(errors[0].msg).to.equal('2012-12-12T00:00:00.000Z');
+      });
+    });
+
     it('receive the value itself when it is string', () => {
       const req = {
         body: { foo: 'bar' }

--- a/utils/to-string.js
+++ b/utils/to-string.js
@@ -7,7 +7,9 @@ module.exports = value => {
 };
 
 function toString(value) {
-  if (value && typeof value === 'object' && value.toString) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  } else if (value && typeof value === 'object' && value.toString) {
     return value.toString();
   } else if (value == null || (isNaN(value) && !value.length)) {
     return '';


### PR DESCRIPTION
Fixes #431 

Highlights from https://github.com/ctavan/express-validator/issues/431#issuecomment-379474024:

> (...) this is an issue of toDate sanitizer combined with isISO8601 validator.
>
> All values are already being coerced into strings for the standard validators, 
with some special rules followed (...) I think Date objects should have a special rule as well.
