### PR TITLE
Update custom validator callback syntax

### DIFF
--- a/docs/feature-custom-validators-sanitizers.md
+++ b/docs/feature-custom-validators-sanitizers.md
@@ -24,6 +24,8 @@ app.post('/user', body('email').custom(value => {
   return User.findUserByEmail(value).then(user => {
     if (user) {
       return Promise.reject('E-mail already in use');
+    } else {
+      Promise.resolve(true);
     }
   });
 }), (req, res) => {
@@ -38,7 +40,9 @@ const { body } = require('express-validator/check');
 app.post('/user', body('passwordConfirmation').custom((value, { req }) => {
   if (value !== req.body.password) {
     throw new Error('Password confirmation does not match password');
-  }
+  } else {
+    return true;
+   }
 }), (req, res) => {
   // Handle the request
 });


### PR DESCRIPTION
It seems that (at least as of version 4.3.0) it's not enough to just reject the promise or throw an error if there's an issue with the validation. The validator needs to resolve or return a truthy value, otherwise an error will be shown to the user.