### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
   # LTS
   - "6"
   - "8"
-  - "9"
   - "10"
+  - "node"
 before_install:
   - npm install -g npm
 install:


### PR DESCRIPTION
Only even release branches become LTS.
Current LTS are 6, 8 and 10. And we should test current stable. Node.js 9 has already reached its EOL.
See https://github.com/nodejs/Release/blob/master/README.md