### PR TITLE
Feature/report failed conditions

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -1,4 +1,5 @@
 import { ReadonlyContext } from './context';
+import { ContextItem } from './context-items';
 
 export interface Request {
   [k: string]: any;
@@ -38,6 +39,7 @@ export type ValidationError =
       // These are optional so places don't need to define them, but can reference them
       location?: undefined;
       value?: undefined;
+      condition?: ContextItem;
     }
   | {
       location: Location;
@@ -46,6 +48,7 @@ export type ValidationError =
       msg: any;
       // This is optional so places don't need to define it, but can reference it
       nestedErrors?: unknown[];
+      condition?: ContextItem;
     };
 
 // Not using Symbol because of #813

--- a/src/context-items/custom-validation.spec.ts
+++ b/src/context-items/custom-validation.spec.ts
@@ -25,7 +25,7 @@ const createSyncTest = (options: { returnValue: any; addsError: boolean }) => as
   validator.mockReturnValue(options.returnValue);
   await validation.run(context, 'bar', meta);
   if (options.addsError) {
-    expect(context.addError).toHaveBeenCalledWith(validation.message, 'bar', meta);
+    expect(context.addError).toHaveBeenCalledWith(validation.message, 'bar', meta, validation);
   } else {
     expect(context.addError).not.toHaveBeenCalled();
   }
@@ -53,13 +53,7 @@ describe('when not negated', () => {
         throw new Error('boom');
       });
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta);
-    });
-
-    it('adds error with validation message if validator returns a promise that rejects', async () => {
-      validator.mockRejectedValue('a bomb');
-      await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta, validation);
     });
   });
 
@@ -73,13 +67,13 @@ describe('when not negated', () => {
         throw new Error('boom');
       });
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('boom', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith('boom', 'bar', meta, validation);
     });
 
     it('adds error with rejection message if validator returns a promise that rejects', async () => {
       validator.mockRejectedValue('a bomb');
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('a bomb', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith('a bomb', 'bar', meta, validation);
     });
   });
 
@@ -123,6 +117,6 @@ describe('when negated', () => {
   it('adds error with validation message if validator returns a promise that resolves', async () => {
     validator.mockResolvedValue(true);
     await validation.run(context, 'bar', meta);
-    expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta);
+    expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta, validation);
   });
 });

--- a/src/context-items/custom-validation.ts
+++ b/src/context-items/custom-validation.ts
@@ -17,14 +17,19 @@ export class CustomValidation implements ContextItem {
       // A promise that was resolved only adds an error if negated.
       // Otherwise it always suceeds
       if ((!isPromise && failed) || (isPromise && this.negated)) {
-        context.addError(this.message, value, meta);
+        context.addError(this.message, value, meta, this);
       }
     } catch (err) {
       if (this.negated) {
         return;
       }
 
-      context.addError(this.message || (err instanceof Error ? err.message : err), value, meta);
+      context.addError(
+        this.message || (err instanceof Error ? err.message : err),
+        value,
+        meta,
+        this,
+      );
     }
   }
 }

--- a/src/context-items/standard-validation.spec.ts
+++ b/src/context-items/standard-validation.spec.ts
@@ -25,7 +25,7 @@ const createTest = (options: { returnValue: any; addsError: boolean }) => async 
   validator.mockReturnValue(options.returnValue);
   await validation.run(context, 'bar', meta);
   if (options.addsError) {
-    expect(context.addError).toHaveBeenCalledWith(validation.message, 'bar', meta);
+    expect(context.addError).toHaveBeenCalledWith(validation.message, 'bar', meta, validation);
   } else {
     expect(context.addError).not.toHaveBeenCalled();
   }

--- a/src/context-items/standard-validation.ts
+++ b/src/context-items/standard-validation.ts
@@ -15,7 +15,7 @@ export class StandardValidation implements ContextItem {
   async run(context: Context, value: any, meta: Meta) {
     const result = this.validator(toString(value), ...this.options);
     if (this.negated ? result : !result) {
-      context.addError(this.message, value, meta);
+      context.addError(this.message, value, meta, this);
     }
   }
 }

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -1,6 +1,7 @@
 import { Context } from './context';
 import { ContextBuilder } from './context-builder';
 import { FieldInstance, Meta } from './base';
+import { StandardValidation } from './context-items';
 
 let context: Context;
 let data: FieldInstance[];
@@ -92,6 +93,25 @@ describe('#addError()', () => {
       param: 'bar',
       location: 'headers',
     });
+  });
+
+  it('includes failed validation condition on error result as nonenumerable property', () => {
+    const meta: Meta = {
+      path: 'bar',
+      location: 'headers',
+      req: {},
+    };
+    let validator: jest.Mock;
+    validator = jest.fn();
+    let validation = new StandardValidation(validator, false);
+    validation.message = 'nope';
+    context.addError('bar', 'foo', meta, validation);
+    let serializedError = JSON.parse(JSON.stringify(context.errors[0]));
+
+    expect(context.errors).toHaveLength(1);
+    expect(context.errors[0]).toHaveProperty('condition', validation);
+    // Nonenumerable property addition will not affect existing express responses
+    expect(serializedError).not.toHaveProperty('condition');
   });
 });
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -72,7 +72,7 @@ export class Context {
     instance.value = value;
   }
 
-  addError(message: any, value: any, meta: Meta, condition: ContextItem): void;
+  addError(message: any, value: any, meta: Meta, condition?: ContextItem): void;
   addError(message: any, nestedErrors: ValidationError[]): void;
   addError(message: any, valueOrNestedErrors: any, meta?: Meta, condition?: ContextItem) {
     const msg = message || this.message || 'Invalid value';

--- a/src/context.ts
+++ b/src/context.ts
@@ -72,23 +72,32 @@ export class Context {
     instance.value = value;
   }
 
-  addError(message: any, value: any, meta: Meta): void;
+  addError(message: any, value: any, meta: Meta, condition: ContextItem): void;
   addError(message: any, nestedErrors: ValidationError[]): void;
-  addError(message: any, valueOrNestedErrors: any, meta?: Meta) {
+  addError(message: any, valueOrNestedErrors: any, meta?: Meta, condition?: ContextItem) {
     const msg = message || this.message || 'Invalid value';
+    let obj: ValidationError;
     if (meta) {
-      this._errors.push({
+      obj = {
         value: valueOrNestedErrors,
         msg: typeof msg === 'function' ? msg(valueOrNestedErrors, meta) : msg,
         param: meta.path,
         location: meta.location,
-      });
+      };
+      if (condition) {
+        Object.defineProperty(obj, 'condition', { value: condition });
+      }
+      this._errors.push(obj);
     } else {
-      this._errors.push({
+      obj = {
         msg,
         param: '_error',
         nestedErrors: valueOrNestedErrors,
-      });
+      };
+      if (condition) {
+        Object.defineProperty(obj, 'condition', { value: condition });
+      }
+      this._errors.push(obj);
     }
   }
 }


### PR DESCRIPTION
## Description

Closes #1124 

Attaching failed validation condition on calls to `context.addError`. This PR adds a nonenumerable property `"condition"` to errors resulting from failed validation. This property is nonenumerable and therefore should not affect any existing express APIs that return output from express-validator. However, it can be used to determine _which_ validation condition failed by reading error output and checking the `condition` property directly. This change maintains express-validator's goal of being unopinionated with regard to error messages while also allowing users to automatically generate human-readable error messages if they want to.

For example, if an input fails an isLength validation, `contextError.condition.constructor.name === 'isLength'`, so I would be able to generate an error message referencing the specific condition that failed rather than a generic message.

_To preserve existing functionality with minimal impact, the `condition` property is always marked optional in the `addError` function signature._

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
