### PR TITLE
docs: fix incorrect default value for isObject strict option

### DIFF
--- a/docs/migration-v6-to-v7.md
+++ b/docs/migration-v6-to-v7.md
@@ -41,20 +41,6 @@ The following types have been removed from express-validator and can be transpar
 | `ValidationParamSchema` | `ParamSchema` |
 | `ValidationSchema`      | `Schema`      |
 
-## Validators
-
-### `isObject()`
-
-The `strict` option, when unset, would default to `false`, meaning that arrays and `null` values would
-pass validation. The new default value is `true`.
-
-To maintain v6.x.x behavior, the following change is necessary:
-
-```diff
-- check('object').isObject()
-+ check('object').isObject({ strict: false })
-```
-
 ## Validation errors
 
 Validation errors used to be objects in the format `{ param, msg, value, location, nestedErrors }`,

--- a/website/versioned_docs/version-7.0.0/migration-v6-to-v7.md
+++ b/website/versioned_docs/version-7.0.0/migration-v6-to-v7.md
@@ -41,20 +41,6 @@ The following types have been removed from express-validator and can be transpar
 | `ValidationParamSchema` | `ParamSchema` |
 | `Validationchema`       | `Schema`      |
 
-## Validators
-
-### `isObject()`
-
-The `strict` option, when unset, would default to `false`, meaning that arrays and `null` values would
-pass validation. The new default value is `true`.
-
-To maintain v6.x.x behavior, the following change is necessary:
-
-```diff
-- check('object').isObject()
-+ check('object').isObject({ strict: false })
-```
-
 ## Validation errors
 
 Validation errors used to be objects in the format `{ param, msg, value, location, nestedErrors }`,

--- a/website/versioned_docs/version-7.2.0/migration-v6-to-v7.md
+++ b/website/versioned_docs/version-7.2.0/migration-v6-to-v7.md
@@ -41,20 +41,6 @@ The following types have been removed from express-validator and can be transpar
 | `ValidationParamSchema` | `ParamSchema` |
 | `ValidationSchema`      | `Schema`      |
 
-## Validators
-
-### `isObject()`
-
-The `strict` option, when unset, would default to `false`, meaning that arrays and `null` values would
-pass validation. The new default value is `true`.
-
-To maintain v6.x.x behavior, the following change is necessary:
-
-```diff
-- check('object').isObject()
-+ check('object').isObject({ strict: false })
-```
-
 ## Validation errors
 
 Validation errors used to be objects in the format `{ param, msg, value, location, nestedErrors }`,

--- a/website/versioned_docs/version-7.3.0/migration-v6-to-v7.md
+++ b/website/versioned_docs/version-7.3.0/migration-v6-to-v7.md
@@ -41,20 +41,6 @@ The following types have been removed from express-validator and can be transpar
 | `ValidationParamSchema` | `ParamSchema` |
 | `ValidationSchema`      | `Schema`      |
 
-## Validators
-
-### `isObject()`
-
-The `strict` option, when unset, would default to `false`, meaning that arrays and `null` values would
-pass validation. The new default value is `true`.
-
-To maintain v6.x.x behavior, the following change is necessary:
-
-```diff
-- check('object').isObject()
-+ check('object').isObject({ strict: false })
-```
-
 ## Validation errors
 
 Validation errors used to be objects in the format `{ param, msg, value, location, nestedErrors }`,


### PR DESCRIPTION
## Description

Fixes #1346

The migration guide incorrectly stated that the `strict` option of `isObject()` defaults to `false`.

The implementation currently defaults `strict` to `true`, so the documentation has been updated to reflect the correct behavior.

Updated the following files:
- docs/migration-v6-to-v7.md
- website/versioned_docs/version-7.0.0/migration-v6-to-v7.md
- website/versioned_docs/version-7.2.0/migration-v6-to-v7.md
- website/versioned_docs/version-7.3.0/migration-v6-to-v7.md

## Checklist

- [x] Documentation updated
- [x] This pull request is ready to merge