### PR TITLE
fix: handle empty array validation in standard validators

### DIFF
--- a/src/context-items/standard-validation.spec.ts
+++ b/src/context-items/standard-validation.spec.ts
@@ -55,6 +55,20 @@ it('calls the validator for each item in array field', async () => {
   expect(validator).toHaveBeenNthCalledWith(2, 'hey42');
 });
 
+it('validates empty array as a single value instead of skipping validation', async () => {
+  toString.mockImplementation(val => `hey${val}`);
+  validator.mockReturnValue(false);
+  await validation.run(context, [], meta);
+  expect(toString).toHaveBeenCalledWith([]);
+  expect(validator).toHaveBeenCalledWith('hey');
+  expect(context.addError).toHaveBeenCalledWith({
+    type: 'field',
+    message: validation.message,
+    value: [],
+    meta,
+  });
+});
+
 it('calls the validator with the value and options', async () => {
   validation = new StandardValidation(validator, false, ['bar', true], toString);
   await validation.run(context, 'foo', meta);

--- a/src/context-items/standard-validation.ts
+++ b/src/context-items/standard-validation.ts
@@ -16,7 +16,7 @@ export class StandardValidation implements ContextItem {
   ) {}
 
   async run(context: Context, value: any, meta: Meta) {
-    const values = Array.isArray(value) ? value : [value];
+    const values = Array.isArray(value) && value.length > 0 ? value : [value];
     values.forEach(value => {
       const result = this.validator(this.stringify(value), ...this.options);
       if (this.negated ? result : !result) {


### PR DESCRIPTION
## Problem

When using `.notEmpty()` on a field that contains an empty array `[]`, no validation error is produced. This is a regression from v6 behavior.

The root cause is in `StandardValidation.run()`:

```ts
const values = Array.isArray(value) ? value : [value];
values.forEach(value => { /* validate */ });
```

When `value = []`, the `forEach` iterates zero times, so validation is silently skipped. The empty array vacuously satisfies any validator, which is incorrect for validators like `notEmpty()` and `isEmpty()`.

## Solution

Changed the array check to also verify the array has items:

```ts
const values = Array.isArray(value) && value.length > 0 ? value : [value];
```

Empty arrays are now treated as a single value and go through the normal stringify path. `toString([])` returns `""`, which correctly evaluates as empty by `validator.isEmpty()`.

## Testing

Added a unit test in `standard-validation.spec.ts` that verifies empty arrays are validated as a single value instead of being skipped.

All existing 311 tests continue to pass, plus the 1 new test (312 total).

Fixes #1243