### PR TITLE
fix: allow default() sanitizer to run on optional missing fields

### DIFF
--- a/src/chain/context-runner-impl.spec.ts
+++ b/src/chain/context-runner-impl.spec.ts
@@ -201,6 +201,18 @@ describe('instance value persistence onto request', () => {
   });
 });
 
+it('runs alwaysRun items with requiredOnly: false', async () => {
+  const alwaysRunItem: ContextItem = { run: jest.fn(), alwaysRun: true };
+  const normalItem: ContextItem = { run: jest.fn() };
+  builder.addItem(normalItem, alwaysRunItem);
+  getDataSpy.mockReturnValue(instances);
+
+  await contextRunner.run({});
+
+  expect(getDataSpy).toHaveBeenNthCalledWith(1, { requiredOnly: true });
+  expect(getDataSpy).toHaveBeenNthCalledWith(2, { requiredOnly: false });
+});
+
 describe('with dryRun: true option', () => {
   it('does not concat to req[contextsKey]', async () => {
     const req: InternalRequest = {};

--- a/src/chain/context-runner-impl.ts
+++ b/src/chain/context-runner-impl.ts
@@ -38,7 +38,8 @@ export class ContextRunnerImpl implements ContextRunner {
     const haltedInstances = new Set<string>();
 
     for (const contextItem of context.stack) {
-      const promises = context.getData({ requiredOnly: true }).map(async instance => {
+      const requiredOnly = !contextItem.alwaysRun;
+      const promises = context.getData({ requiredOnly }).map(async instance => {
         const { location, path } = instance;
         const instanceKey = `${location}:${path}`;
         if (haltedInstances.has(instanceKey)) {

--- a/src/chain/sanitizers-impl.spec.ts
+++ b/src/chain/sanitizers-impl.spec.ts
@@ -234,11 +234,13 @@ describe('#toUpperCase()', () => {
 });
 
 describe('#default()', () => {
-  it('adds default() sanitizer to the context', () => {
+  it('adds default() sanitizer to the context with alwaysRun flag', () => {
     const ret = sanitizers.default(5);
 
     expect(ret).toBe(chain);
-    expect(builder.addItem).toHaveBeenCalledWith(new Sanitization(expect.any(Function), true));
+    expect(builder.addItem).toHaveBeenCalledWith(
+      new Sanitization(expect.any(Function), true, [], undefined, true),
+    );
   });
 
   it('sanitizes to default()', async () => {

--- a/src/chain/sanitizers-impl.ts
+++ b/src/chain/sanitizers-impl.ts
@@ -15,9 +15,10 @@ export class SanitizersImpl<Chain> implements Sanitizers<Chain> {
     return this.chain;
   }
   default(default_value: any) {
-    return this.customSanitizer(value =>
-      [undefined, null, NaN, ''].includes(value) ? _.cloneDeep(default_value) : value,
-    );
+    const sanitizer: CustomSanitizer = value =>
+      [undefined, null, NaN, ''].includes(value) ? _.cloneDeep(default_value) : value;
+    this.builder.addItem(new Sanitization(sanitizer, true, [], undefined, true));
+    return this.chain;
   }
   replace(values_to_replace: any, new_value: any) {
     if (!Array.isArray(values_to_replace)) {

--- a/src/context-items/context-item.ts
+++ b/src/context-items/context-item.ts
@@ -3,4 +3,5 @@ import { Context } from '../context';
 
 export interface ContextItem {
   run(context: Context, value: any, meta: Meta): Promise<void>;
+  readonly alwaysRun?: boolean;
 }

--- a/src/context-items/sanitization.ts
+++ b/src/context-items/sanitization.ts
@@ -11,6 +11,7 @@ export class Sanitization implements ContextItem {
     // For testing only.
     // Deliberately not calling it `toString` in order to not override `Object.prototype.toString`.
     private readonly stringify = toStringImpl,
+    readonly alwaysRun = false,
   ) {}
 
   async run(context: Context, value: any, meta: Meta) {


### PR DESCRIPTION
## Problem

When `optional()` and `default()` are chained together in the same validation chain, the `default()` sanitizer never executes on missing fields:

```ts
// This does NOT apply the default value
body('children').isArray().optional().default([])

// Workaround: splitting into two chains works
body('children').isArray().optional()
body('children').default([])
```

The root cause is in `ContextRunnerImpl.run()`, which calls `context.getData({ requiredOnly: true })` for every context item in the stack. When `optional()` is set and the field value is `undefined`, the field instance gets filtered out before the `default()` sanitizer can process it.

## Solution

Added an `alwaysRun` flag to the `ContextItem` interface. When set to `true`, the context runner calls `getData({ requiredOnly: false })` for that item, allowing it to process optional missing fields.

The `default()` sanitizer now sets `alwaysRun: true` on its `Sanitization` instance, so it can apply default values even when the field is optional and missing.

Other sanitizers like `trim()` are unaffected — they don't set this flag and continue to respect the optional filter.

### Changes

- `src/context-items/context-item.ts` — Added optional `alwaysRun` property to interface
- `src/context-items/sanitization.ts` — Added `alwaysRun` constructor parameter
- `src/chain/sanitizers-impl.ts` — `default()` creates Sanitization with `alwaysRun: true`
- `src/chain/context-runner-impl.ts` — Checks `contextItem.alwaysRun` for `requiredOnly`

## Testing

- Updated existing `default()` unit test to verify the `alwaysRun` flag
- Added test in `context-runner-impl.spec.ts` verifying `alwaysRun` items use `requiredOnly: false`
- All 312 tests pass

Fixes #1057