### PR TITLE
fix(deps): bump lodash to 4.17.23 to fix CVE-2025-13465

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14342,9 +14342,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -32986,9 +32987,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "lodash.debounce": {
       "version": "4.0.8",


### PR DESCRIPTION
## Problem

The currently pinned lodash version (4.17.21) is affected by [CVE-2025-13465](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg), a moderate severity prototype pollution vulnerability in `_.unset` and `_.omit`.

## Solution

Updated `package-lock.json` to resolve lodash to 4.17.23, which patches this vulnerability. The `package.json` dependency range (`^4.17.21`) already allows this version.

## Testing

All 311 existing tests pass with the updated dependency.

Fixes #1350