### PR TITLE
fix: preserve array structure in matchedData with wildcard validation

### DIFF
--- a/src/matched-data.spec.ts
+++ b/src/matched-data.spec.ts
@@ -38,6 +38,20 @@ it('includes data that was validated with wildcards', done => {
   });
 });
 
+it('returns an array when body is an array validated with wildcards', done => {
+  const req = {
+    body: [{ name: 'John' }, { name: 'Jane' }],
+  };
+
+  check('*.name', ['body']).isString()(req, {}, () => {
+    const data = matchedData(req, { locations: ['body'] });
+    expect(Array.isArray(data)).toBe(true);
+    expect(data).toEqual([{ name: 'John' }, { name: 'Jane' }]);
+
+    done();
+  });
+});
+
 it('does not include valid data from invalid oneOf() chain group', done => {
   const req = {
     query: { foo: 'foo', bar: 123, baz: 'baz' },

--- a/src/matched-data.ts
+++ b/src/matched-data.ts
@@ -44,12 +44,21 @@ export function matchedData<T extends object = Record<string, any>>(
   const validityFilter = createValidityFilter(options.onlyValidData);
   const locationFilter = createLocationFilter(options.locations);
 
-  return _(internalReq[contextsKey])
+  const instances = _(internalReq[contextsKey])
     .flatMap(fieldExtractor)
     .filter(validityFilter)
     .map(field => field.instance)
     .filter(locationFilter)
-    .reduce((state, instance) => _.set(state, instance.path, instance.value), {} as T);
+    .value();
+
+  const shouldBeArray =
+    instances.length > 0 &&
+    instances.every(instance => /^\d+$/.test(_.toPath(instance.path)[0]));
+
+  return instances.reduce(
+    (state, instance) => _.set(state, instance.path, instance.value),
+    (shouldBeArray ? [] : {}) as T,
+  );
 }
 
 function createFieldExtractor(removeOptionals: boolean) {


### PR DESCRIPTION
## Problem

When the request body is an array and validated using wildcards, `matchedData()` returns an object with numeric string keys instead of preserving the array structure:

```ts
// body: [{name: 'John Doe'}]
// validation: checkSchema({'*.name': {in: 'body', isString: true}})

matchedData(req, { locations: ['body'] })
// Returns: {'0': {name: 'John Doe'}}
// Expected: [{name: 'John Doe'}]
```

The root cause is in `matchedData()` where the reduce accumulator is always initialized as `{}`. When lodash's `_.set()` receives an object with numeric paths like `[0].name`, it creates object properties with string keys instead of array elements.

## Solution

Before running the reduce, check if all top-level path segments are numeric indices. If so, initialize the accumulator as `[]` instead of `{}`, which lets lodash correctly build an array structure.

```ts
const shouldBeArray =
  instances.length > 0 &&
  instances.every(instance => /^\d+$/.test(_.toPath(instance.path)[0]));

return instances.reduce(
  (state, instance) => _.set(state, instance.path, instance.value),
  (shouldBeArray ? [] : {}) as T,
);
```

Non-numeric top-level paths (like `foo`, `bar.baz`) are unaffected — they continue to produce a plain object.

## Testing

Added a test that validates an array body with wildcards and verifies the result is an array. All 312 tests pass.

Fixes #915