### PR TITLE
docs: fix incorrect checkSchema().run() example

### DIFF
--- a/docs/api/check-schema.md
+++ b/docs/api/check-schema.md
@@ -46,13 +46,15 @@ you can also run it manually, if you wish.
 
 ```ts
 app.post('/signup', async (req, res) => {
-  const result = await checkSchema({
+  const results = await checkSchema({
     email: { isEmail: true },
     password: { isLength: { options: { min: 8 } } },
   }).run(req);
 
-  if (!result.isEmpty()) {
-    console.log('Failed validation');
+  const hasErrors = results.some(result => !result.isEmpty());
+  if (hasErrors) {
+    const errors = results.flatMap(result => result.array());
+    return res.status(400).json({ errors });
   }
 });
 ```


### PR DESCRIPTION
## Problem

The "Manually running checkSchema()" example in the docs calls `result.isEmpty()` on the return value of `checkSchema().run()`:

```ts
const result = await checkSchema({...}).run(req);
if (!result.isEmpty()) { // TypeError: result.isEmpty is not a function
```

But `checkSchema().run()` returns `ResultWithContext[]` (an array of results), not a single `Result`. This causes `TypeError: result.isEmpty is not a function` at runtime.

## Solution

Updated the example to correctly handle the array of results:

```ts
const results = await checkSchema({...}).run(req);
const hasErrors = results.some(result => !result.isEmpty());
if (hasErrors) {
  const errors = results.flatMap(result => result.array());
  return res.status(400).json({ errors });
}
```

Fixes #1298