### PR TITLE
docs: fix incorrect type references in oneOf and validation-result docs

### DIFF
--- a/docs/api/one-of.md
+++ b/docs/api/one-of.md
@@ -123,8 +123,8 @@ oneOf(
 ### `least_errored` {#error-type-least-errored}
 
 Sets `oneOf()` to add a
-[`AlternativeValidationError` error](./validation-result.md#groupedalternativevalidationerror)
-when none of the validation chain groups are valid.  
+[`AlternativeValidationError` error](./validation-result.md#alternativevalidationerror)
+when none of the validation chain groups are valid.
 The error's `nestedErrors` property includes all errors from the validation chain group that had the
 least errors.
 
@@ -170,8 +170,8 @@ oneOf(
 ### `flat` {#error-type-flat}
 
 Sets `oneOf()` to add a
-[`AlternativeValidationError` error](./validation-result.md#groupedalternativevalidationerror)
-when none of the validation chain groups are valid.  
+[`AlternativeValidationError` error](./validation-result.md#alternativevalidationerror)
+when none of the validation chain groups are valid.
 The error's `nestedErrors` property is a list of all errors from every validation chains passed to
 `oneOf()`.
 

--- a/docs/api/validation-result.md
+++ b/docs/api/validation-result.md
@@ -263,7 +263,7 @@ Represents an error caused when all alternatives (e.g. in [`oneOf()`](./one-of.m
 ### `GroupedAlternativeValidationError`
 
 ```ts
-type AlternativeValidationError = {
+type GroupedAlternativeValidationError = {
   type: 'alternative_grouped';
   msg: any;
   nestedErrors: FieldValidationError[][];


### PR DESCRIPTION
## Summary

- Fix incorrect anchor links in the `oneOf()` docs: both the `least_errored` and `flat` error type sections linked to `#groupedalternativevalidationerror` instead of the correct `#alternativevalidationerror`. These error types produce `AlternativeValidationError`, not `GroupedAlternativeValidationError`.
- Fix incorrect type name in the `validation-result` docs: the code block under the `GroupedAlternativeValidationError` section showed the type name as `AlternativeValidationError` instead of `GroupedAlternativeValidationError`.

## Details

In `docs/api/one-of.md`, lines for `least_errored` and `flat` sections both had:
```md
[`AlternativeValidationError` error](./validation-result.md#groupedalternativevalidationerror)
```
Fixed to:
```md
[`AlternativeValidationError` error](./validation-result.md#alternativevalidationerror)
```

In `docs/api/validation-result.md`, the code block under `### GroupedAlternativeValidationError` had:
```ts
type AlternativeValidationError = {
```
Fixed to:
```ts
type GroupedAlternativeValidationError = {
```