### PR TITLE
docs: fix duplicate variable declaration in matchedData example

### DIFF
--- a/docs/api/matched-data.md
+++ b/docs/api/matched-data.md
@@ -113,7 +113,7 @@ app.post(
       return res.send('Please fix the request');
     }
 
-    const result = matchedData<{
+    const data = matchedData<{
       email: string;
       message: string;
       phone?: string;


### PR DESCRIPTION
## Summary

- Fix duplicate `const result` declaration in the TypeScript usage example of `matchedData()` docs

## Details

The TypeScript usage example at the bottom of `docs/api/matched-data.md` declared `const result` twice:

```ts
const result = validationResult(req); // line 110
// ...
const result = matchedData<{...}>(req); // line 116 - duplicate!
```

Renamed the second declaration to `const data` to avoid the compile error and to match the naming pattern used in all other examples on the same page.