### PR TITLE
docs: fix missing async keywords and dryRun type in ContextRunner examples

### DIFF
--- a/docs/api/misc.md
+++ b/docs/api/misc.md
@@ -30,7 +30,7 @@ app.put(
 
 ```ts
 interface ContextRunner {
-  run(req: Request, options?: { dryRun: boolean }): Promise<Result>;
+  run(req: Request, options?: { dryRun?: boolean }): Promise<Result>;
 }
 ```
 
@@ -41,7 +41,7 @@ chain/middleware.
 
 ```ts
 import { check } from 'express-validator';
-app.post('/recover-password', (req, res) => {
+app.post('/recover-password', async (req, res) => {
   const result = await check('username').notEmpty().run(req);
   if (!result.isEmpty()) {
     return res.send('Something is wrong with the username.');
@@ -59,7 +59,7 @@ and return the result.
 
 ```ts
 import { check } from 'express-validator';
-app.post('/login', (req, res) => {
+app.post('/login', async (req, res) => {
   const usernameResult = await check('username').notEmpty().run(req, { dryRun: true });
   const passwordResult = await check('password').notEmpty().run(req, { dryRun: false });
   const result = validationResult(req);


### PR DESCRIPTION
## Summary

- Add missing `async` keyword to two route handlers that use `await` in the ContextRunner docs
- Fix `dryRun` property type from required to optional to match the actual `ContextRunningOptions` type

## Details

In `docs/api/misc.md`:

1. The `ContextRunner` interface signature showed `{ dryRun: boolean }` but the actual type is `{ dryRun?: boolean }` (optional). Fixed to match the source code.

2. Two code examples used `await` inside non-async route handlers:
```ts
// Before (invalid - await without async):
app.post('/recover-password', (req, res) => {
  const result = await check('username').notEmpty().run(req);

// After (valid):
app.post('/recover-password', async (req, res) => {
  const result = await check('username').notEmpty().run(req);
```