### PR TITLE
fix(checkExact): detect unknown fields under wildcard when specific sub-paths are declared

### DIFF
--- a/src/field-selection.spec.ts
+++ b/src/field-selection.spec.ts
@@ -488,6 +488,31 @@ describe('selectUnknownFields()', () => {
     });
   });
 
+  it('selects unknown fields when wildcard parent and specific sub-paths are both declared', () => {
+    // When '*' and '*.foo' are both in knownFields, the specific sub-path '*.foo' defines
+    // what is known under each wildcard element. Fields other than 'foo' should be unknown.
+    const req = { body: { obj1: { foo: 1, bar: 2 }, obj2: { foo: 3, baz: 4 } } };
+    const instances = selectUnknownFields(req, ['*', '*.foo'], ['body']);
+    expect(instances).toHaveLength(2);
+    expect(instances[0]).toMatchObject({
+      path: 'obj1.bar',
+      value: 2,
+      location: 'body',
+    });
+    expect(instances[1]).toMatchObject({
+      path: 'obj2.baz',
+      value: 4,
+      location: 'body',
+    });
+  });
+
+  it('does not select any fields when wildcard parent is declared without specific sub-paths', () => {
+    // When only '*' is in knownFields (no specific sub-paths), all element contents are implicitly known.
+    const req = { body: { foo: 1, bar: 2 } };
+    const instances = selectUnknownFields(req, ['*'], ['body']);
+    expect(instances).toHaveLength(0);
+  });
+
   it('does not select any fields at a globstar level', () => {
     const req = { body: { foo: 1, bar: { baz: 2 } } };
     const instances = selectUnknownFields(req, ['**'], ['body']);

--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -153,11 +153,36 @@ function pathToTree(segments: string[], tree: Tree) {
 }
 
 /**
+ * Returns true when a tree branch is "covered as a whole" — meaning all descendants
+ * are implicitly known and no further traversal is needed.
+ *
+ * A branch is covered as a whole only when it has the empty-string leaf (`''`) AND
+ * no more-specific sub-keys. When specific sub-keys co-exist with `''`, the sub-keys
+ * take precedence: only the listed sub-paths are known, and anything else is unknown.
+ *
+ * Example:
+ *   - `{ '': {} }` — fully covered, no specific sub-paths → returns true
+ *   - `{ '': {}, 'id': { '': {} } }` — has specific sub-key 'id' → returns false
+ *     so that only 'id' (and any other declared sub-keys) are treated as known
+ */
+function isCoveredAsWhole(tree: Tree): boolean {
+  if (!tree['']) {
+    return false;
+  }
+  // If there are specific sub-keys beyond '' and '**', they define constrained knowledge.
+  // In that case the '' marker only means "this field's value is validated" but
+  // does not imply all nested fields are implicitly known.
+  const hasSpecificSubKeys = Object.keys(tree).some(k => k !== '' && k !== '**');
+  return !hasSpecificSubKeys;
+}
+
+/**
  * Performs a depth-first search for unknown fields in `value`.
  * The path to the unknown fields will be pushed to the `unknownFields` argument.
  *
  * Known fields must be passed via `tree`. A field won't be considered unknown if:
- * - its branch is validated as a whole; that is, it contains an empty string key (e.g `{ ['']: {} }`); OR
+ * - its branch is validated as a whole; that is, it contains an empty string key (e.g `{ ['']: {} }`)
+ *   with no more-specific sub-keys; OR
  * - its path is individually validated; OR
  * - it's covered by a wildcard (`*`).
  *
@@ -171,7 +196,7 @@ function findUnknownFields(
   unknownFields: UnknownFieldInstance[] = [],
 ): UnknownFieldInstance[] {
   const globstarBranch = tree['**'];
-  if (tree[''] || globstarBranch?.['']) {
+  if (isCoveredAsWhole(tree) || globstarBranch?.['']) {
     // The rest of the tree from here is covered by some validation chain
     // For example, when the current treePath is `['foo', 'bar']` but `foo` is known
     return unknownFields;

--- a/src/middlewares/exact.spec.ts
+++ b/src/middlewares/exact.spec.ts
@@ -1,6 +1,6 @@
+import { body, check } from './validation-chain-builders';
 import { checkExact } from './exact';
 import { checkSchema } from './schema';
-import { check } from './validation-chain-builders';
 
 it.each([
   ['single chain', check('banana')],
@@ -85,5 +85,69 @@ it('works as a middleware', done => {
   const req = {};
   checkExact([])(req, {}, () => {
     done();
+  });
+});
+
+describe('wildcard field validation', () => {
+  it('detects unknown nested fields when wildcard parent and specific sub-paths are both declared', async () => {
+    // body('*') validates each array element, body('*.id') and body('*.qty') declare specific sub-fields.
+    // A field like 'wrong' nested inside an array element should be flagged as unknown.
+    const req = {
+      body: [
+        { id: 1, qty: 100 },
+        { id: 2, wrong: 1, qty: 100 },
+      ],
+    };
+    const result = await checkExact([
+      body().isArray(),
+      body('*').isObject(),
+      body('*.id').isInt(),
+      body('*.qty').isInt(),
+    ]).run(req);
+    const errors = result.array();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      type: 'unknown_fields',
+      fields: [{ path: '[1].wrong', value: 1, location: 'body' }],
+    });
+  });
+
+  it('does not flag unknown fields when only wildcard parent is declared (no specific sub-paths)', async () => {
+    // When body('*') is used without any specific sub-paths, the wildcard fully covers all elements.
+    const req = {
+      body: [{ id: 1, qty: 100 }],
+    };
+    const result = await checkExact([body('*').isObject()]).run(req);
+    expect(result.isEmpty()).toBe(true);
+  });
+
+  it('detects unknown fields using checkSchema with wildcard paths', async () => {
+    const req = {
+      body: [
+        { id: 1, qty: 100 },
+        { id: 2, extra: 'bad', qty: 100 },
+      ],
+    };
+    const result = await checkExact(
+      checkSchema({
+        '*.id': { in: ['body'], isInt: true },
+        '*.qty': { in: ['body'], isInt: true },
+      }),
+    ).run(req);
+    const errors = result.array();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      type: 'unknown_fields',
+      fields: [{ path: '[1].extra', value: 'bad', location: 'body' }],
+    });
+  });
+
+  it('allows all array element fields when no sub-paths are declared for the wildcard', async () => {
+    // No sub-paths for '*': everything inside each element is implicitly covered.
+    const req = {
+      body: [{ id: 1, qty: 100, extra: 'any' }],
+    };
+    const result = await checkExact([body('*')]).run(req);
+    expect(result.isEmpty()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1242.

When `checkExact` is used together with wildcard validation chains (e.g. `body('*').isObject()`) alongside specific sub-path chains (e.g. `body('*.id')`, `body('*.qty')`), unknown nested fields inside array elements are not detected. A field like `wrong` in `[{ id: 1, qty: 100 }, { id: 2, wrong: 1, qty: 100 }]` passes `checkExact` without any error.

## Root Cause

`selectUnknownFields` builds a tree of known field paths. When `body('*')` is registered, it creates the tree `{ '*': { '': {} } }`. The `''` leaf in `findUnknownFields` means "this branch is validated as a whole — all descendants are implicitly known", causing the function to short-circuit and skip children. This happens even when more specific sub-paths like `*.id` and `*.qty` are also in the tree (producing `{ '*': { '': {}, 'id': { '': {} }, 'qty': { '': {} } } }`), because the `''` check fires first.

## Fix

Introduce `isCoveredAsWhole(tree)` which returns `true` only when:
1. The `''` leaf is present, AND
2. There are **no** more-specific sub-keys (other than `''` and `'**'`)

When specific sub-keys co-exist with `''`, those sub-keys define constrained knowledge. The `''` marker means "the field's value is validated" but does NOT imply all descendants are implicitly known. Anything not listed as a specific sub-key is flagged as unknown.

## Behaviour

| Known fields | Request | Unknown fields detected |
|---|---|---|
| `['*']` only | `[{ id: 1, extra: 2 }]` | none (fully covered by wildcard) |
| `['*', '*.id', '*.qty']` | `[{ id: 1, qty: 100, wrong: 1 }]` | `[0].wrong` |
| `['*.id', '*.qty']` | `[{ id: 1, qty: 100, wrong: 1 }]` | `[0].wrong` |

## Test plan

- New tests added in `src/middlewares/exact.spec.ts` covering the wildcard + specific sub-paths scenario with both `checkExact` chains and `checkSchema`.
- New tests added in `src/field-selection.spec.ts` covering `selectUnknownFields` directly.
- All 317 tests pass (`npm test`).