### PR TITLE
docs: fix ReferenceError by adding param to ExpressValidator destructuring example

### DIFF
--- a/docs/guides/customizing.md
+++ b/docs/guides/customizing.md
@@ -162,7 +162,7 @@ For example, [custom validators, sanitizers](#custom-validators-and-sanitizers),
 ```ts
 import { ExpressValidator } from 'express-validator';
 
-const { body, validationResult } = new ExpressValidator(
+const { body, param, validationResult } = new ExpressValidator(
   {
     isPostID: async value => {
       // Verify if the value matches the post ID format


### PR DESCRIPTION
Add `param` to the destructuring list when instantiating new ExpressValidator

## Description

Add `param` to the destructuring list in the ExpressValidator instance documentation example. Without it, the code snippet throws a ReferenceError: param is not defined error.

All runner functions must be destructured from the specific custom instance so that they have access to the configured custom validators and sanitizers.

<!-- Describe what you changed and link to the relevant issue(s) -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
